### PR TITLE
Monoid corrections

### DIFF
--- a/src/pages/monoids/index.md
+++ b/src/pages/monoids/index.md
@@ -64,7 +64,7 @@ Note that we used `++` for string concatentation instead of the more usual `+` t
 We've seen a number of types that we can "add" and have an identity element. It will be no surprise to learn that this is a monoid. Formally, a monoid for a type `A` is:
 
 - an operation `append` with type `(A, A) => A`; and
-- an element `zero` of type `A.
+- an element `zero` of type `A`.
 
 The following laws must hold:
 

--- a/src/pages/monoids/scalaz.md
+++ b/src/pages/monoids/scalaz.md
@@ -83,6 +83,7 @@ We can alternatively write the fold using `Monoids`, although there's not a comp
 ~~~ scala
 import scalaz.Monoid
 import scalaz.syntax.monoid._
+import scalaz.std.anyVal._
 
 def add(items: List[Int]): Int =
   items.foldLeft(mzero[Int]){ _ |+| _ }

--- a/src/pages/monoids/scalaz.md
+++ b/src/pages/monoids/scalaz.md
@@ -89,7 +89,7 @@ def add(items: List[Int]): Int =
 ~~~
 </div>
 
-Well done! SuperAdder's market share continues to grow, and now there is demand for additional functionality. People now want to add `List[Option[Int]]`. Change `add` so this is possible. The SuperAdder code base is of the highest quality, so make sure there is no code duplication:
+Well done! SuperAdder's market share continues to grow, and now there is demand for additional functionality. People now want to add `List[Option[Int]]`. Change `add` so this is possible. The SuperAdder code base is of the highest quality, so make sure there is no code duplication.
 
 <div class="solution">
 Now there is a use case for `Monoids`. We need a single method that adds `Ints` and instances of `Option[Int]`. We can write this as a generic method that accepts an implicit `Monoid` as a parameter:


### PR DESCRIPTION
All pretty tiny.

Loved the SuperAdder:tm: market share growing :-)  

One thing I noticed about the example: the monoid for `Order` produces a result I wouldn't want on my bill. Buying two things at $100, plus one at $25 gives an order of 3 things at $125. Which totals to $375 compared to the $225 I might expect.

An alternative might be:

``` scala
implicit val monoid: Monoid[Order] =
  Monoid.instance[Order](
     (o1, o2) => Order(o1.totalCost * o1.quantity + o2.totalCost * o2.quantity, 1), 
    Order(0d, 0d) )
```

...but maybe you already have enough exercises there.
