### PR TITLE
Functor corrections

### DIFF
--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -75,7 +75,7 @@ If you haven't seen syntax like `F[_]` before, it's time to take a brief detour 
 
 ## Aside: Higher Kinds and Type Constructors
 
-Kinds are like types for types. The describe the number of "holes" in a type. We distinguish between regular types that have no holes, and "type constructors" that have holes that we can fill to produce types.
+Kinds are like types for types. They describe the number of "holes" in a type. We distinguish between regular types that have no holes, and "type constructors" that have holes that we can fill to produce types.
 
 For example, `List` is a type constructor with one hole. We fill that hole by specifying a parameter to produce a regular type like `List[Int]` or `List[A]`. The trick is not to confuse type constructors with generic types. `List` is a type constructor, `List[A]` is a type:
 

--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -1,6 +1,6 @@
 # Functors
 
-In this section we will investigate **functors**. Functors on their own aren't so useful, but special cases of functors such as as **monads** and **applicative functors** are some of the most commonly used abstractions in Scalaz.
+In this chapter we will investigate **functors**. Functors on their own aren't so useful, but special cases of functors such as as **monads** and **applicative functors** are some of the most commonly used abstractions in Scalaz.
 
 Let's start as we did with monoids by looking at a few types and operations and seeing what general principles we can abstract.
 

--- a/src/pages/functors/scalaz.md
+++ b/src/pages/functors/scalaz.md
@@ -16,7 +16,7 @@ Functor[List].map(List(1, 2, 3))(x => x * 2)
 Functor[Option].map(Some(123))(_.toString)
 ~~~
 
-`Functor` also provides the `lift` method, which converts an function of type `A => B` to one that operates over a monad and has type `F[A] => F[B]`:
+`Functor` also provides the `lift` method, which converts a function of type `A => B` to one that operates over a monad and has type `F[A] => F[B]`:
 
 ~~~ scala
 val lifted = Functor[Option].lift((x: Int) => x + 1)

--- a/src/pages/functors/scalaz.md
+++ b/src/pages/functors/scalaz.md
@@ -32,6 +32,7 @@ The main method provided by the syntax for `Functor` is `map`:
 
 ~~~ scala
 import scalaz.std.option._
+import scalaz.std.function._
 import scalaz.syntax.functor._
 
 val f = ((a: Int) => a + 1) map ((a: Int) => a * 2)

--- a/src/pages/functors/scalaz.md
+++ b/src/pages/functors/scalaz.md
@@ -86,6 +86,7 @@ It is sensible to assume that we want to apply the `Functor's` mapping function 
 
 ~~~ scala
 import scalaz.Functor
+import scalaz.syntax.functor._
 
 implicit val resultFunctor = new Functor[Result] {
   def map[A, B](result: Result[A])(func: A => B): Result[B] =

--- a/src/pages/functors/scalaz.md
+++ b/src/pages/functors/scalaz.md
@@ -34,6 +34,7 @@ The main method provided by the syntax for `Functor` is `map`:
 import scalaz.std.option._
 import scalaz.std.function._
 import scalaz.syntax.functor._
+import scalaz.Monad
 
 val f = ((a: Int) => a + 1) map ((a: Int) => a * 2)
 

--- a/src/pages/functors/scalaz.md
+++ b/src/pages/functors/scalaz.md
@@ -106,7 +106,7 @@ Success(100) map (_ * 2)
 //                            ^
 ~~~
 
-Oops! This is the same inavariance problem we saw with `Monoids`. Let's add some smart constructors to compensate:
+Oops! This is the same invariance problem we saw with `Monoids`. Let's add some smart constructors to compensate:
 
 ~~~ scala
 def success[A](value: A): Result[A] = Success(value)


### PR DESCRIPTION
Small typos and a couple of missing imports.

I notice the functor summary.md is commented out of the _metadata.yaml_ - probably intentional, but mentioning it in case it was just forgotten about.

Under the heading _Functions (?!)_, we talk about "shape" in two ways: the shape of the example (line 29), and the shape of functions (line 35). We don't say what shape is at any point. Maybe we mean just the pattern; maybe we mean polymorphic. It might be nice to nail what wel mean by the "shape" of a thing.
