### PR TITLE
Typo in example of map on Option

### DIFF
--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -56,7 +56,7 @@ Option(1).map(_.toString)
 We expect `map` on  `Option` to behave in the same way as `List`:
 
 ```tut:book
-Option(123).map(_ * 4).map(_ + 4)
+Option(123).map(_ * 2).map(_ + 4)
 
 Option(123).map(x => (x * 2) + 4)
 ```


### PR DESCRIPTION
It says (_ * 4) when it should be ( _ * 2 ) in order to have the same result as it is compared ( x * 2) + 4