### PR TITLE
Added missing import in solution for "B3 Adding all the things"

### DIFF
--- a/src/pages/monoids/cats.md
+++ b/src/pages/monoids/cats.md
@@ -151,6 +151,7 @@ We can alternatively write the fold using `Monoids`,
 although there's not a compelling use case for this yet:
 
 ```tut:book:silent
+import cats.instances.int._
 import cats.Monoid
 import cats.syntax.semigroup._
 

--- a/src/pages/monoids/cats.md
+++ b/src/pages/monoids/cats.md
@@ -151,8 +151,8 @@ We can alternatively write the fold using `Monoids`,
 although there's not a compelling use case for this yet:
 
 ```tut:book:silent
-import cats.instances.int._
 import cats.Monoid
+import cats.instances.int._
 import cats.syntax.semigroup._
 
 def add(items: List[Int]): Int =


### PR DESCRIPTION
This PR adds a missing import to the solution of the exercise `B3 Adding all the things` (chapter on monoids).

Without the import, the compiler doesn't know where to find an implementation of a semigroup for int.  As a result, the compiler complains that:
```
Error:(12, 27) could not find implicit value for parameter ev: cats.kernel.Monoid[Int]
    items.foldLeft(Monoid[Int].empty)(_ |+| _)
                         ^
```