### PR TITLE
Addendum to the description of solution for "B2 All set for monoids"

### DIFF
--- a/src/pages/monoids/index.md
+++ b/src/pages/monoids/index.md
@@ -288,4 +288,7 @@ implicit def setIntersectionSemigroup[A]: Semigroup[Set[A]] =
       a intersect b
   }
 ```
+
+Set complement and set difference are not associative,
+so they cannot be considered for either monoids or semigroups.
 </div>


### PR DESCRIPTION
When doing this exercise I did the mistake of considering set difference for a semigroup.

I had to google it to fully convince me that difference is not associative.........
......and if Google says so it must be true! 💃 

In this PR I propose an addendum to the solution to clarify that set difference and set complement are non-associative, so they cannot be considered valid for a semigroup or monoid.

Free feel to rephrase the sentence as you please.