### PR TITLE
Few small issues in "Defining Custom Monads"

### DIFF
--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -1,7 +1,7 @@
 ## Defining Custom Monads
 
 We can define a `Monad` for a custom type
-by providing implementations of thee methods:
+by providing implementations of three methods:
 `flatMap`, `pure`, and a new method called `tailRecM`.
 Here is an implementation of `Monad` for `Option` as an example:
 

--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -34,7 +34,7 @@ the amount of stack space used by nested calls to `flatMap`.
 The technique comes from a [2015 paper][link-phil-freeman-tailrecm]
 by PureScript creator Phil Freeman.
 The method should recursively call itself
-as long as the result of `f` returns a `Right`.
+until the result of `fn` returns a `Right`.
 If we can make `tailRecM` tail recursive,
 we should do so to allow Cats to perform
 additional internal optimisations.


### PR DESCRIPTION
- typo: "thee methods" instead of "three methods"
- function from `tailRecM` example referred to as `f` in the text but `fn` in the example
- the recursion ends if the result is a `Left`, not  if it's a `Right`.

Wasn't sure whether to fix the third item to say "until right" or "as long as left" but [this tutorial](http://eed3si9n.com/herding-cats/tail-recursive-monads.html#FlatMap+%28MonadRec%29) says "until a right is returned" and seemed pretty clear.