### PR TITLE
Fixed typos

### DIFF
--- a/src/pages/monads/either.md
+++ b/src/pages/monads/either.md
@@ -295,7 +295,7 @@ result2.fold(handleError, println)
 
 ### Exercise: What is Best?
 
-Is the error handling strategy in the previous exercises
+Is the error handling strategy in the previous examples
 well suited for all purposes?
 What other features might we want from error handling?
 

--- a/src/pages/monads/eval.md
+++ b/src/pages/monads/eval.md
@@ -263,7 +263,7 @@ def factorial(n: BigInt): Eval[BigInt] =
 factorial(50000).value
 ```
 
-`Eval` is a useful tool to enforce stack
+`Eval` is a useful tool to enforce stack safety
 when working on very large computations and data structures.
 However, we must bear in mind that trampolining is not free.
 It avoids consuming stack by creating a chain of function calls on the heap.


### PR DESCRIPTION
1. text refers to previous exercises, but should be examples as the previous exercise belongs to a different chapter
2. missing word