### PR TITLE
Add comment about interface syntax

### DIFF
--- a/src/pages/type-classes/implicits.md
+++ b/src/pages/type-classes/implicits.md
@@ -225,8 +225,10 @@ Without this keyword, the compiler won't be able to
 fill in the parameters during implicit resolution.
 
 `implicit` methods with non-`implicit` parameters
-form a different Scala pattern called an *implicit conversion*.
-This is an older programming pattern
+form a different Scala pattern called an *implicit conversion*. 
+This is also different from the previous section on `Interface Syntax`, 
+because in that case the `JsonWriter` is an implicit class with `extension methods`. 
+Implicit conversion is an older programming pattern
 that is frowned upon in modern Scala code.
 Fortunately, the compiler will warn you when you do this.
 You have to manually enable implicit conversions


### PR DESCRIPTION
The `Implicit Conversions` note section confused me because I was applying it to the earlier example of "interface syntax" (the note seemed to indicate that the implicit class without an implicit param could be considered an implicit conversion). I added a comment saying that since it's an implicit class, it is not classified as an implicit conversion—let me know if this is accurate. 