### PR TITLE
Simpler tailRecM solution

### DIFF
--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -111,23 +111,10 @@ implicit val treeMonad = new Monad[Tree] {
 
  def tailRecM[A, B](arg: A)
      (func: A => Tree[Either[A, B]]): Tree[B] =
-   func(arg) match {
-     case Branch(l, r) =>
-       Branch(
-         flatMap(l) {
-           case Left(l)  => tailRecM(l)(func)
-           case Right(l) => pure(l)
-         },
-         flatMap(r) {
-           case Left(r)  => tailRecM(r)(func)
-           case Right(r) => pure(r)
-         }
-       )
-
-     case Leaf(Left(value)) =>
+   flatMap(func(a)) {
+     case Left(value) =>
        tailRecM(value)(func)
-
-     case Leaf(Right(value)) =>
+     case Right(value) =>
        Leaf(value)
    }
 }


### PR DESCRIPTION
Seems like I found easier non-tail-recursive tailRecM implementation for exercise _D.12: Branching out Further with Monads_, compared to implementation in book :) At least, I don't see any differences in behaviour.