### PR TITLE
Avoid copy-paste in PrintableSyntax solution

### DIFF
--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -158,10 +158,10 @@ First we define an `implicit class` containing our extension methods:
 object PrintableSyntax {
   implicit class PrintableOps[A](value: A) {
     def format(implicit p: Printable[A]): String =
-      p.format(value)
+      Printable.format(value)
 
     def print(implicit p: Printable[A]): Unit =
-      println(p.format(value))
+      Printable.print(value)
   }
 }
 ```


### PR DESCRIPTION
The `print` extension method in the solution was defining `print` again via `println`. It should rely on the definition inside `Printable` instead.