### PR TITLE
fix import for semigroupal instance

### DIFF
--- a/src/pages/applicatives/semigroupal.md
+++ b/src/pages/applicatives/semigroupal.md
@@ -165,11 +165,11 @@ Here's an example:
 
 ```tut:book:silent
 import cats.Monoid
-import cats.instances.boolean._ // for Monoid
-import cats.instances.int._     // for Monoid
-import cats.instances.list._    // for Monoid
-import cats.instances.string._  // for Monoid
-import cats.syntax.apply._      // for imapN
+import cats.instances.int._        // for Monoid
+import cats.instances.invariant._  // for Semigroupal
+import cats.instances.list._       // for Monoid
+import cats.instances.string._     // for Monoid
+import cats.syntax.apply._         // for imapN
 
 case class Cat(
   name: String,


### PR DESCRIPTION
Boolean monoid is not needed, but we need a monoid semigroupal/invariant for `imapN`.