### PR TITLE
fixing two typos in index.md and cats.md

### DIFF
--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -227,7 +227,7 @@ Let's use our `Functor` to transform some `Trees`:
 Branch(Leaf(10), Leaf(20)).map(_ * 2)
 ```
 
-Oops! This is falls foul of
+Oops! This falls foul of
 the same invariance problem we discussed in Section [@sec:variance].
 The compiler can find a `Functor` instance for `Tree` but not for `Branch` or `Leaf`.
 Let's add some smart constructors to compensate:

--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -76,7 +76,7 @@ that apply the pattern in different ways.
 `Future` is a functor that
 sequences asynchronous computations by queueing them
 and applying them as their predecessors complete.
-The type signuture of its `map` method,
+The type signature of its `map` method,
 shown in Figure [@fig:functors:future-type-chart],
 has the same shape as the signatures above.
 However, the behaviour is very different.


### PR DESCRIPTION
I am confident about index.md one, not completely for the cats.md one.