### PR TITLE
Fix assorted typos

### DIFF
--- a/src/pages/foldable-traverse/foldable-cats.md
+++ b/src/pages/foldable-traverse/foldable-cats.md
@@ -109,7 +109,7 @@ it's useful to know that `Eval` has our back.
 
 `Foldable` provides us with
 a host of useful methods defined on top of `foldLeft`.
-Many of these are facsimiles of familiar methods from the standard library:
+Many of these are facimiles of familiar methods from the standard library:
 `find`, `exists`, `forall`, `toList`, `isEmpty`, `nonEmpty`, and so on:
 
 ```tut:book

--- a/src/pages/foldable-traverse/foldable-cats.md
+++ b/src/pages/foldable-traverse/foldable-cats.md
@@ -109,7 +109,7 @@ it's useful to know that `Eval` has our back.
 
 `Foldable` provides us with
 a host of useful methods defined on top of `foldLeft`.
-Many of these are facimiles of familiar methods from the standard library:
+Many of these are facsimiles of familiar methods from the standard library:
 `find`, `exists`, `forall`, `toList`, `isEmpty`, `nonEmpty`, and so on:
 
 ```tut:book

--- a/src/pages/functors/partial-unification.md
+++ b/src/pages/functors/partial-unification.md
@@ -69,7 +69,7 @@ However, earlier versions of the Scala compiler
 were not able to make this inference.
 This infamous limitation,
 known as [SI-2712][link-si2712],
-prevented the compiler "unifying" type constructors
+prevented the compiler from "unifying" type constructors
 of different arities.
 This compiler limitation is now fixed,
 although we have to enable the fix

--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -103,7 +103,7 @@ each named with a `T` suffix:
 
 Here's an example that uses `OptionT`
 to compose `List` and `Option`.
-We can use `OptionT[List, A]`,
+We can use can `OptionT[List, A]`,
 aliased to `ListOption[A]` for convenience,
 to transform a `List[Option[A]]` into a single monad:
 

--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -526,7 +526,7 @@ def getPowerLevel(autobot: String): Response[Int] =
 
 Transmissions take time in Earth's viscous atmosphere,
 and messages are occasionally lost
-due to satellite malfunction or sabotaged by pesky Decepticons[^transformers].
+due to satellite malfunction or sabotage by pesky Decepticons[^transformers].
 `Responses` are therefore represented as a stack of monads:
 
 ```tut:book

--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -103,7 +103,7 @@ each named with a `T` suffix:
 
 Here's an example that uses `OptionT`
 to compose `List` and `Option`.
-We can use can `OptionT[List, A]`,
+We can use `OptionT[List, A]`,
 aliased to `ListOption[A]` for convenience,
 to transform a `List[Option[A]]` into a single monad:
 
@@ -231,7 +231,7 @@ represented in Cats as
 We can now reveal that `Kleisli` and `ReaderT`
 are, in fact, the same thing!
 `ReaderT` is actually a type alias for `Kleisli`.
-Hence why we were creating `Readers` last chapter
+Hence, we were creating `Readers` last chapter
 and seeing `Kleislis` on the console.
 </div>
 
@@ -443,7 +443,7 @@ to operate on them in different contexts.
 We can cope with this in multiple ways.
 One approach involves creating a single "super stack"
 and sticking to it throughout our code base.
-This works if the code simple and largely uniform in nature.
+This works if the code is simple and largely uniform in nature.
 For example, in a web application,
 we could decide that all request handlers are asynchronous
 and all can fail with the same set of HTTP error codes.
@@ -526,7 +526,7 @@ def getPowerLevel(autobot: String): Response[Int] =
 
 Transmissions take time in Earth's viscous atmosphere,
 and messages are occasionally lost
-due to satellite malfunction or sabotage by pesky Decepticons[^transformers].
+due to satellite malfunction or sabotaged by pesky Decepticons[^transformers].
 `Responses` are therefore represented as a stack of monads:
 
 ```tut:book

--- a/src/pages/monads/index.md
+++ b/src/pages/monads/index.md
@@ -11,7 +11,7 @@ We even have special syntax to support monads: for comprehensions.
 However, despite the ubiquity of the concept,
 the Scala standard library lacks
 a concrete type to encompass "things that can be `flatMapped`".
-This type class is one of the benefits bought to us by Cats.
+This type class is one of the benefits brought to us by Cats.
 
 In this chapter we will take a deep dive into monads.
 We will start by motivating them with a few examples.


### PR DESCRIPTION
Fixes some typos I found here and there :smile: 

- prevented the compiler "unifying" -> prevented the compiler from "unifying"
- Hence why we were creating -> Hence, we were creating
- This works if the code simple -> This works if the code is simple
- benefits bought to us -> benefits brought to us