### PR TITLE
Commutative -> Associative

### DIFF
--- a/src/pages/foldable-traverse/foldable.md
+++ b/src/pages/foldable-traverse/foldable.md
@@ -41,7 +41,7 @@ Figure [@fig:foldable-traverse:fold] illustrates each direction.
 ![Illustration of foldLeft and foldRight](src/pages/foldable-traverse/fold.pdf+svg){#fig:foldable-traverse:fold}
 
 `foldLeft` and `foldRight` are equivalent
-if our binary operation is commutative.
+if our binary operation is associative.
 For example, we can sum a `List[Int]` by folding in either direction,
 using `0` as our accumulator and addition as our operation:
 
@@ -50,7 +50,7 @@ List(1, 2, 3).foldLeft(0)(_ + _)
 List(1, 2, 3).foldRight(0)(_ + _)
 ```
 
-If we provide a non-commutative operator
+If we provide a non-associative operator
 the order of evaluation makes a difference.
 For example, if we fold using subtraction,
 we get different results in each direction:


### PR DESCRIPTION
Terribly sorry to bring up such a pedantic point. Please feel free to dismiss me and/or tell me I'm wrong.

_Scala with Cats_ section 7.1 says:
> foldLeft and foldRight are equivalent if our binary operation is commutative.

My reading of [Runar's answer](https://stackoverflow.com/a/6255094) is that `foldLeft` and `foldRight` are equivalent if the operation is _associative_ but as he says replying to Rex, "Commutativity is not really relevant here." 

The latter point I understand to be true because the "side-ed-ness" of the operation is preserved because the binary op passed to `foldLeft` and `foldRight` flip which side the accumulator appears on.

To the specific example in the text, 
```
(((0 + 1) + 2) + 3) == (1 + (2 + (3 + 0)))
```
looks like (my daughter's) elementary text book examples of associativity to me.