### PR TITLE
fix a compile error in a code snippet

### DIFF
--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -79,7 +79,7 @@ a definition of `flatMap` comes to light:
 ```scala
 def flatMap[A, B](fa: Composed[A])
     (f: A => Composed[B]): Composed[B] =
-  fa.flatMap(_.fold(None.pure[M1])(f))
+  fa.flatMap(_.fold[Composed[B]](None.pure[M1])(f))
 ```
 
 Notice that the definition above makes use of `None`---an


### PR DESCRIPTION
This PR fixes a compile error in a snippet in chapter5.

I tried this sample assuming M1 to be List as follows:

```
def flatMap[A, B](fa: Composed[A])(f: A => Composed[B]): Composed[B] =
   fa.flatMap (_.fold(None.pure[List])(f))
```

I got the following error at compile time.

```
[error] /Users/a14215/Desktop/projects/scala-with-cats/cats/src/main/scala/com/github/saint1991/cats/chapter5/Main.scala:22:43: type mismatch;
[error]  found   : A => com.github.saint1991.cats.chapter5.Main.Composed[B]
[error]     (which expands to)  A => List[Option[B]]
[error]  required: A => List[None.type]
[error]       fa.flatMap (_.fold(None.pure[List])(f))
```

It seems to fail to infer the type of `f` correctly from the 1st argument `None.pure[M1]`.
I explicitly declare the type parameter for `fold` as follows:
```
def flatMap[A, B](fa: Composed[A])(f: A => Composed[B]): Composed[B] =
      fa.flatMap (_.fold[Composed[B]](None.pure[List])(f))
```

and it works for me!