### PR TITLE
PrintableSyntax solution minor improvement

### DIFF
--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -158,10 +158,10 @@ First we define an `implicit class` containing our extension methods:
 object PrintableSyntax {
   implicit class PrintableOps[A](value: A) {
     def format(implicit p: Printable[A]): String =
-      Printable.format(value)
+      p.format(value)
 
     def print(implicit p: Printable[A]): Unit =
-      Printable.print(value)
+      println(format(p))
   }
 }
 ```


### PR DESCRIPTION
I'd suggest it's better to use the type class instance directly instead of depending on and mixing with Printable object which is another approach to using type class. I think this better reflect the purpose of the exercise and the actual use case.