### PR TITLE
Change expr1 which doesn't exists to F

### DIFF
--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -120,7 +120,7 @@ new FunctorOps(foo).map(value => value + 1)
 The `map` method of `FunctorOps` requires
 an implicit `Functor` as a parameter.
 This means this code will only compile
-if we have a `Functor` for `expr1` in scope.
+if we have a `Functor` for `F` in scope.
 If we don't, we get a compiler error:
 
 ```tut:book:silent


### PR DESCRIPTION
This is better since reader won't look around for `expr1` and frustrated when they can't find it. By changing it to `F`, they can find it in the definition of FunctorOps.