### PR TITLE
Adding missing import for higherKinds

### DIFF
--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -396,6 +396,7 @@ to suppress warnings from the compiler.
 We can either do this with a "language import" as above:
 
 ```scala
+import scala.language.higherKinds
 ```
 
 or by adding the following to `scalacOptions` in `build.sbt`:


### PR DESCRIPTION
Adding the missing import for higher kinds in the docs.

Note: We no longer need this for Scala 2.13.1 onwards, however, as the source is based on an earlier version of Scala, it's worth correcting this.