### PR TITLE
Commenting out an example that was hidden

### DIFF
--- a/src/pages/applicatives/validated.md
+++ b/src/pages/applicatives/validated.md
@@ -258,7 +258,7 @@ to fail with a specified error
 if a predicate does not hold:
 
 ```scala mdoc
-// 123.valid[String].ensure("Negative!")(_ > 0)
+123.valid[String].ensure("Negative!")(_ > 0)
 ```
 
 Finally, we can call `getOrElse` or `fold`


### PR DESCRIPTION
This is a commented out example that, when un-commenting and running `sbt html`, it can be displayed without errors. Maybe I'm missing the bigger context to why this example is commented out. This PR is in case that was not the case.