### PR TITLE
use * in kind projector example

### DIFF
--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -353,7 +353,7 @@ For example:
 ```scala mdoc
 import cats.instances.option._ // for Monad
 
-123.pure[EitherT[Option, String, ?]]
+123.pure[EitherT[Option, String, *]]
 ```
 
 Kind Projector can't simplify all type declarations down to a single line,


### PR DESCRIPTION
`?` is deprecated now, and `*` replace that role.

https://github.com/typelevel/kind-projector/issues/108