### PR TITLE
handleWith should be handleError

### DIFF
--- a/src/pages/monads/monad-error.md
+++ b/src/pages/monads/monad-error.md
@@ -101,7 +101,7 @@ monadError.handleErrorWith(failure) {
 ```
 
 If we know we can handle all possible errors 
-we can use `handleWith`.
+we can use `handleError`.
 
 ```scala mdoc
 monadError.handleError(failure) {


### PR DESCRIPTION
in the comment section of the `handleError` example, it is listed as `handleWith`