### PR TITLE
Adding solution with ensureOr to MonadError exercise

### DIFF
--- a/src/pages/monads/monad-error.md
+++ b/src/pages/monads/monad-error.md
@@ -213,4 +213,16 @@ def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int]
   if(age >= 18) age.pure[F]
   else new IllegalArgumentException("Age must be greater than or equal to 18").raiseError[F, Int]
 ```
+
+Another way of solving it is using `pure` and `ensure`.
+
+```scala mdoc:invisible:reset-object
+import cats.MonadError
+import cats.implicits._
+```
+
+```scala mdoc:silent
+def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] = 
+  age.pure[F].ensure(new IllegalArgumentException("Age must be greater than or equal to 18"))(_ >= 18)
+```
 </div>


### PR DESCRIPTION
The exercise `4.5.4: Abstracting` asks the reader to write a signature for the method 
```scala
def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] = ???
```
The proposed solutions shows the usage of `pure` and `raiseError` and uses and if:
```scala
def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] =
  if(age >= 18) age.pure[F]
  else new IllegalArgumentException("Age must be greater than or equal to 18").raiseError[F, Int]
```
but since in the chapter the exercises refers to is specified that "Cats provides syntax for `raiseError` and `handleErrorWith` via `cats.syntax.applicativeError` and `ensure` via `cats.syntax.monadError`" it makes sense to me to show a solution that uses the `ensure` API like this:

```scala
def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] = 
  age.pure[F].ensure(new IllegalArgumentException("Age must be greater than or equal to 18"))(_ >= 18)
```

Plus, I personally love oneliners :P
