### PR TITLE
Fix example in §3.5.2

### DIFF
--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -86,8 +86,10 @@ def doMath[F[_]](start: F[Int])
     (implicit functor: Functor[F]): F[Int] =
   start.map(n => n + 1 * 2)
 
+import cats.Functor
 import cats.instances.option._ // for Functor
 import cats.instances.list._   // for Functor
+import cats.syntax.functor._   // for map
 ```
 
 ```scala mdoc


### PR DESCRIPTION
The current example makes the compiler complain that `value map is not a member of type parameter F[Int]` (and that `parameter value functor in method doMath is never used`).