### PR TITLE
Add missing import in exercise solution

### DIFF
--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -218,6 +218,7 @@ with the same pattern of `Branch` and `Leaf` nodes:
 
 ```scala mdoc:silent
 import cats.Functor
+import cats.syntax.functor._     // for map
 
 implicit val treeFunctor: Functor[Tree] =
   new Functor[Tree] {


### PR DESCRIPTION
Without this import the example code fails with "error: value map is not a member of Tree[Int]".