### PR TITLE
WIP: Scala 3 Overhaul

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,11 +14,14 @@ enablePlugins(MdocPlugin)
 mdocIn  := sourceDirectory.value / "pages"
 mdocOut := target.value          / "pages"
 
+scalacOptions ++= Seq(
+  "-explain", // Better diagnostics
+  "-Ykind-projector:underscores" // In-lieu of kind-projector
+)
+
 val catsVersion  = "2.9.0"
 
 libraryDependencies ++= Seq("org.typelevel" %% "cats-core" % catsVersion)
-
-addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
 
 mdocVariables := Map(
   "SCALA_VERSION" -> scalaVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / name               := "scala-with-cats"
 ThisBuild / organization       := "com.scalawithcats"
 ThisBuild / version            := "0.0.1"
 
-ThisBuild / scalaVersion       := "2.13.8"
+ThisBuild / scalaVersion       := "3.2.2"
 
 ThisBuild / useSuperShell      := false
 Global    / logLevel           := Level.Warn

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ enablePlugins(MdocPlugin)
 mdocIn  := sourceDirectory.value / "pages"
 mdocOut := target.value          / "pages"
 
-val catsVersion  = "2.7.0"
+val catsVersion  = "2.9.0"
 
 libraryDependencies ++= Seq("org.typelevel" %% "cats-core" % catsVersion)
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "devDependencies": {
     "bootstrap": "^3.4.1",
     "coffeeify": "1.0.0",
+    "coffeescript": "^2.5.1",
     "jquery": "3.5.0",
-    "uglifyify": "2.6.0",
     "lessc": "^1.0.2",
-    "underscore": "1.7.0",
     "pandoc-filter": "0.1.6",
-    "coffeescript": "^2.5.1"
+    "uglifyify": "2.6.0",
+    "underscore": "1.7.0"
   },
   "author": "Noel Welsh and Dave Gurnell"
 }

--- a/project/Pandoc.scala
+++ b/project/Pandoc.scala
@@ -118,7 +118,7 @@ object Pandoc {
         "--table-of-contents",
         "--highlight-style tango",
         "--standalone",
-        "--self-contained",
+        "--embed-resources",
       ),
       extras,
       metadata,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.0" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7" )
 // addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.10")

--- a/src/pages/adt/scala.md
+++ b/src/pages/adt/scala.md
@@ -20,10 +20,8 @@ Not everyone makes their case classes `final`, but they should. A non-`final` ca
 A logical or (a sum type) is represented by an `enum`. For the sum type `A` is a `B` **or** `C` the Scala 3 representation is
 
 ```scala
-enum A {
-  case B
-  case C
-}
+enum A:
+  case B, C
 ```
 
 There are a few wrinkles to be aware of. 
@@ -37,10 +35,9 @@ If we have a sum of products, such as:
 the representation is
 
 ```scala
-enum A {
+enum A:
   case B(d: D, e: E)
   case C(f: F, g: G)
-}
 ```
 
 In other words you can't write `final case class` inside an `enum`. You also can't nest `enum` inside `enum`. Nested logical ors can be rewritten into a single logical or containing only logical ands (known as disjunctive normal form) so this is not a limitation in practice. However the Scala 2 representation is still available in Scala 3 should you want more expressivity.

--- a/src/pages/adt/scala.md
+++ b/src/pages/adt/scala.md
@@ -43,7 +43,7 @@ enum A {
 }
 ```
 
-In other words you can't write `final case class` inside an `enum`. You also can't nest `enum` inside `enum`. Nexted logical ors  can be rewritten into a single logical or containing only logical ands (known as disjunctive normal form) so this is not a limitation in practice. However the Scala 2 representation is still available in Scala 3 should you want more expressivity.
+In other words you can't write `final case class` inside an `enum`. You also can't nest `enum` inside `enum`. Nested logical ors can be rewritten into a single logical or containing only logical ands (known as disjunctive normal form) so this is not a limitation in practice. However the Scala 2 representation is still available in Scala 3 should you want more expressivity.
 
 
 ### Algebraic Data Types in Scala 2

--- a/src/pages/applicatives/applicative.md
+++ b/src/pages/applicatives/applicative.md
@@ -24,16 +24,14 @@ introduced in Chapter [@sec:monads].
 Here's a simplified definition in code:
 
 ```scala
-trait Apply[F[_]] extends Semigroupal[F] with Functor[F] {
+trait Apply[F[_]] extends Semigroupal[F] with Functor[F]:
   def ap[A, B](ff: F[A => B])(fa: F[A]): F[B]
 
   def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] =
     ap(map(fa)(a => (b: B) => (a, b)))(fb)
-}
 
-trait Applicative[F[_]] extends Apply[F] {
+trait Applicative[F[_]] extends Apply[F]:
   def pure[A](a: A): F[A]
-}
 ```
 
 Breaking this down, the `ap` method applies a parameter `fa`

--- a/src/pages/applicatives/examples.md
+++ b/src/pages/applicatives/examples.md
@@ -12,9 +12,9 @@ provide parallel as opposed to sequential execution:
 
 ```scala mdoc:silent
 import cats.Semigroupal
-import cats.instances.future._ // for Semigroupal
-import scala.concurrent._
-import scala.concurrent.duration._
+import cats.instances.future.* // for Semigroupal
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 
 val futurePair = Semigroupal[Future].
@@ -31,7 +31,7 @@ by the time we call `product`.
 We can use apply syntax to zip fixed numbers of `Futures`:
 
 ```scala mdoc:silent
-import cats.syntax.apply._ // for mapN
+import cats.syntax.apply.* // for mapN
 
 case class Cat(
   name: String,
@@ -59,7 +59,7 @@ but we actually get the cartesian product of their elements:
 
 ```scala mdoc:silent
 import cats.Semigroupal
-import cats.instances.list._ // for Semigroupal
+import cats.instances.list.* // for Semigroupal
 ```
 
 ```scala mdoc
@@ -81,7 +81,7 @@ we find that `product` implements
 the same fail-fast behaviour as `flatMap`:
 
 ```scala mdoc:silent
-import cats.instances.either._ // for Semigroupal
+import cats.instances.either.* // for Semigroupal
 
 type ErrorOr[A] = Either[Vector[String], A]
 ```
@@ -105,8 +105,8 @@ If we have a monad we can implement `product` as follows.
 
 ```scala mdoc:silent
 import cats.Monad
-import cats.syntax.functor._ // for map
-import cats.syntax.flatMap._ // for flatmap
+import cats.syntax.functor.* // for map
+import cats.syntax.flatMap.* // for flatmap
 
 def product[F[_]: Monad, A, B](fa: F[A], fb: F[B]): F[(A,B)] =
   fa.flatMap(a => 
@@ -178,8 +178,8 @@ the definition of `product` in terms of
 import cats.Monad
 ```
 ```scala mdoc:silent
-import cats.syntax.functor._ // for map
-import cats.syntax.flatMap._ // for flatMap
+import cats.syntax.functor.* // for map
+import cats.syntax.flatMap.* // for flatMap
 
 def product[F[_]: Monad, A, B](x: F[A], y: F[B]): F[(A, B)] =
   x.flatMap(a => y.map(b => (a, b)))
@@ -189,8 +189,8 @@ This code is equivalent to a for comprehension:
 
 ```scala mdoc:invisible:reset-object
 import cats.Monad
-import cats.syntax.flatMap._ // for flatMap
-import cats.syntax.functor._ // for map
+import cats.syntax.flatMap.* // for flatMap
+import cats.syntax.functor.* // for map
 ```
 ```scala mdoc:silent
 def product[F[_]: Monad, A, B](x: F[A], y: F[B]): F[(A, B)] =
@@ -204,7 +204,7 @@ The semantics of `flatMap` are what give rise
 to the behaviour for `List` and `Either`:
 
 ```scala mdoc:silent
-import cats.instances.list._ // for Semigroupal
+import cats.instances.list.* // for Semigroupal
 ```
 
 ```scala mdoc

--- a/src/pages/applicatives/index.md
+++ b/src/pages/applicatives/index.md
@@ -19,7 +19,7 @@ fails on the first call to `parseInt`
 and doesn't go any further:
 
 ```scala mdoc:silent
-import cats.syntax.either._ // for catchOnly
+import cats.syntax.either.* // for catchOnly
 
 def parseInt(str: String): Either[String, Int] =
   Either.catchOnly[NumberFormatException](str.toInt).

--- a/src/pages/applicatives/parallel.md
+++ b/src/pages/applicatives/parallel.md
@@ -88,13 +88,12 @@ Let's dig into how `Parallel` works.
 The definition below is the core of `Parallel`.
 
 ```scala
-trait Parallel[M[_]] {
+trait Parallel[M[_]]:
   type F[_]
   
   def applicative: Applicative[F]
   def monad: Monad[M]
   def parallel: ~>[M, F]
-}
 ```
 
 This tells us if there is a `Parallel` instance for some type constructor `M` then:

--- a/src/pages/applicatives/parallel.md
+++ b/src/pages/applicatives/parallel.md
@@ -115,13 +115,11 @@ by defining a `FunctionK` that converts an `Option` to a `List`.
 ```scala mdoc:silent
 import cats.arrow.FunctionK
 
-object optionToList extends FunctionK[Option, List] {
+object optionToList extends FunctionK[Option, List]:
   def apply[A](fa: Option[A]): List[A] =
-    fa match {
+    fa match
       case None    => List.empty[A]
       case Some(a) => List(a)
-    }
-}
 ```
 ```scala mdoc
 optionToList(Some(1))

--- a/src/pages/applicatives/parallel.md
+++ b/src/pages/applicatives/parallel.md
@@ -17,7 +17,7 @@ stops at the first error.
 
 ```scala mdoc:silent
 import cats.Semigroupal
-import cats.instances.either._ // for Semigroupal
+import cats.instances.either.* // for Semigroupal
 
 type ErrorOr[A] = Either[Vector[String], A]
 val error1: ErrorOr[Int] = Left(Vector("Error 1"))
@@ -33,8 +33,8 @@ using `tupled`
 as a short-cut.
 
 ```scala mdoc:silent
-import cats.syntax.apply._ // for tupled
-import cats.instances.vector._ // for Semigroup on Vector
+import cats.syntax.apply.* // for tupled
+import cats.instances.vector.* // for Semigroup on Vector
 ```
 ```scala mdoc
 (error1, error2).tupled
@@ -45,7 +45,7 @@ we simply replace `tupled` with its "parallel" version
 called `parTupled`.
 
 ```scala mdoc:silent
-import cats.syntax.parallel._ // for parTupled
+import cats.syntax.parallel.* // for parTupled
 ```
 ```scala mdoc
 (error1, error2).parTupled
@@ -57,7 +57,7 @@ Any type that has a `Semigroup` instance will work.
 For example, here we use `List` instead.
 
 ```scala mdoc:silent
-import cats.instances.list._ // for Semigroup on List
+import cats.instances.list.* // for Semigroup on List
 
 type ErrorOrList[A] = Either[List[String], A]
 val errStr1: ErrorOrList[Int] = Left(List("error 1"))
@@ -160,7 +160,7 @@ insted of creating the cartesian product.
 We can see by writing a little bit of code.
 
 ```scala mdoc:silent
-import cats.instances.list._
+import cats.instances.list.*
 ```
 ```scala mdoc
 (List(1, 2), List(3, 4)).tupled

--- a/src/pages/applicatives/semigroupal.md
+++ b/src/pages/applicatives/semigroupal.md
@@ -34,7 +34,7 @@ Let's join some `Options` as an example:
 
 ```scala mdoc:silent:reset-object
 import cats.Semigroupal
-import cats.instances.option._ // for Semigroupal
+import cats.instances.option.* // for Semigroupal
 ```
 
 ```scala mdoc
@@ -59,7 +59,7 @@ For example, the methods `tuple2` through `tuple22`
 generalise `product` to different arities:
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Semigroupal
+import cats.instances.option.* // for Semigroupal
 ```
 
 ```scala mdoc
@@ -98,8 +98,8 @@ We import the syntax from [`cats.syntax.apply`][cats.syntax.apply].
 Here's an example:
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Semigroupal
-import cats.syntax.apply._     // for tupled and mapN
+import cats.instances.option.* // for Semigroupal
+import cats.syntax.apply.*     // for tupled and mapN
 ```
 
 The `tupled` method is implicitly added to the tuple of `Options`.
@@ -167,11 +167,11 @@ Here's an example:
 
 ```scala mdoc:silent:reset-object
 import cats.Monoid
-import cats.instances.int._        // for Monoid
-import cats.instances.invariant._  // for Semigroupal
-import cats.instances.list._       // for Monoid
-import cats.instances.string._     // for Monoid
-import cats.syntax.apply._         // for imapN
+import cats.instances.int.*        // for Monoid
+import cats.instances.invariant.*  // for Semigroupal
+import cats.instances.list.*       // for Monoid
+import cats.instances.string.*     // for Monoid
+import cats.syntax.apply.*         // for imapN
 
 final case class Cat(
   name: String,
@@ -196,7 +196,7 @@ Our `Monoid` allows us to create "empty" `Cats`,
 and add `Cats` together using the syntax from Chapter [@sec:monoids]:
 
 ```scala mdoc:silent
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.semigroup.* // for |+|
 
 val garfield   = Cat("Garfield", 1978, List("Lasagne"))
 val heathcliff = Cat("Heathcliff", 1988, List("Junk Food"))

--- a/src/pages/applicatives/semigroupal.md
+++ b/src/pages/applicatives/semigroupal.md
@@ -185,7 +185,7 @@ val tupleToCat: (String, Int, List[String]) => Cat =
 val catToTuple: Cat => (String, Int, List[String]) =
   cat => (cat.name, cat.yearOfBirth, cat.favoriteFoods)
 
-implicit val catMonoid: Monoid[Cat] = (
+given catMonoid: Monoid[Cat] = (
   Monoid[String],
   Monoid[Int],
   Monoid[List[String]]

--- a/src/pages/applicatives/semigroupal.md
+++ b/src/pages/applicatives/semigroupal.md
@@ -7,9 +7,8 @@ a `Semigroupal[F]` allows us to combine them to form an `F[(A, B)]`.
 Its definition in Cats is:
 
 ```scala
-trait Semigroupal[F[_]] {
+trait Semigroupal[F[_]]:
   def product[A, B](fa: F[A], fb: F[B]): F[(A, B)]
-}
 ```
 
 As we discussed at the beginning of this chapter,

--- a/src/pages/applicatives/validated.md
+++ b/src/pages/applicatives/validated.md
@@ -21,7 +21,7 @@ is therefore free to accumulate errors:
 ```scala mdoc:silent
 import cats.Semigroupal
 import cats.data.Validated
-import cats.instances.list._ // for Monoid
+import cats.instances.list.* // for Monoid
 
 type AllErrorsOr[A] = Validated[List[String], A]
 ```
@@ -59,7 +59,7 @@ which widen the return type to `Validated`:
 
 ```scala mdoc:invisible:reset-object
 import cats.data.Validated
-import cats.instances.list._ // for Monoid
+import cats.instances.list.* // for Monoid
 
 type AllErrorsOr[A] = Validated[List[String], A]
 ```
@@ -73,7 +73,7 @@ the `valid` and `invalid` extension methods
 from `cats.syntax.validated`:
 
 ```scala mdoc:silent
-import cats.syntax.validated._ // for valid and invalid
+import cats.syntax.validated.* // for valid and invalid
 ```
 
 ```scala mdoc
@@ -87,8 +87,8 @@ and [`cats.syntax.applicativeError`][cats.syntax.applicativeError]
 respectively:
 
 ```scala mdoc:silent
-import cats.syntax.applicative._      // for pure
-import cats.syntax.applicativeError._ // for raiseError
+import cats.syntax.applicative.*      // for pure
+import cats.syntax.applicativeError.* // for raiseError
 
 type ErrorsOr[A] = Validated[List[String], A]
 ```
@@ -130,7 +130,7 @@ number of parameters for `Semigroupal`:
 ```scala mdoc:invisible:reset-object
 import cats.data.Validated
 import cats.Semigroupal
-import cats.syntax.validated._
+import cats.syntax.validated.*
 ```
 ```scala mdoc:silent
 type AllErrorsOr[A] = Validated[String, A]
@@ -149,7 +149,7 @@ Once we import a `Semigroup` for the error type,
 everything works as expected:
 
 ```scala mdoc:silent
-import cats.instances.string._ // for Semigroup
+import cats.instances.string.* // for Semigroup
 ```
 
 ```scala mdoc
@@ -163,7 +163,7 @@ or any of the other `Semigroupal` methods
 to accumulate errors as we like:
 
 ```scala mdoc:silent
-import cats.syntax.apply._ // for tupled
+import cats.syntax.apply.* // for tupled
 ```
 
 ```scala mdoc
@@ -178,7 +178,7 @@ for accumulating errors.
 We commonly use `Lists` or `Vectors` instead:
 
 ```scala mdoc:silent
-import cats.instances.vector._ // for Semigroupal
+import cats.instances.vector.* // for Semigroupal
 ```
 
 ```scala mdoc
@@ -246,7 +246,7 @@ using the `toEither` and `toValidated` methods.
 Note that `toValidated` comes from [`cats.syntax.either`]:
 
 ```scala mdoc
-import cats.syntax.either._ // for toValidated
+import cats.syntax.either.* // for toValidated
 
 "Badness".invalid[Int]
 "Badness".invalid[Int].toEither
@@ -371,7 +371,7 @@ and we use `leftMap` to
 turn it into an error message:
 
 ```scala mdoc:silent
-import cats.syntax.either._ // for catchOnly
+import cats.syntax.either.* // for catchOnly
 
 type NumFmtExn = NumberFormatException
 
@@ -468,8 +468,8 @@ We can do this by switching from `Either` to `Validated`
 and using apply syntax:
 
 ```scala mdoc:silent
-import cats.instances.list._ // for Semigroupal
-import cats.syntax.apply._   // for mapN
+import cats.instances.list.* // for Semigroupal
+import cats.syntax.apply.*   // for mapN
 
 def readUser(data: FormData): FailSlow[User] =
   (

--- a/src/pages/case-studies/crdt/abstraction.md
+++ b/src/pages/case-studies/crdt/abstraction.md
@@ -40,14 +40,12 @@ object BoundedSemiLattice {
     val empty: Int =
       0
 
-  implicit def setInstance[A]: BoundedSemiLattice[Set[A]] =
-    new BoundedSemiLattice[Set[A]]{
-      def combine(a1: Set[A], a2: Set[A]): Set[A] =
-        a1 union a2
+  given setInstance[A]: BoundedSemiLattice[Set[A]] with
+    def combine(a1: Set[A], a2: Set[A]): Set[A] =
+      a1 union a2
 
-      val empty: Set[A] =
-        Set.empty[A]
-    }
+    val empty: Set[A] =
+      Set.empty[A]
 }
 ```
 ```scala mdoc:silent
@@ -86,22 +84,20 @@ import cats.instances.map._    // for Monoid
 import cats.syntax.semigroup._ // for |+|
 import cats.syntax.foldable._  // for combineAll
 
-implicit def mapGCounterInstance[K, V]: GCounter[Map, K, V] =
-  new GCounter[Map, K, V] {
-    def increment(map: Map[K, V])(key: K, value: V)
-          (using m: CommutativeMonoid[V]): Map[K, V] = {
-      val total = map.getOrElse(key, m.empty) |+| value
-      map + (key -> total)
-    }
-
-    def merge(map1: Map[K, V], map2: Map[K, V])
-          (using b: BoundedSemiLattice[V]): Map[K, V] =
-      map1 |+| map2
-
-    def total(map: Map[K, V])
-        (using m: CommutativeMonoid[V]): V =
-      map.values.toList.combineAll
+given mapGCounterInstance[K, V]: GCounter[Map, K, V] with
+  def increment(map: Map[K, V])(key: K, value: V)
+        (using m: CommutativeMonoid[V]): Map[K, V] = {
+    val total = map.getOrElse(key, m.empty) |+| value
+    map + (key -> total)
   }
+
+  def merge(map1: Map[K, V], map2: Map[K, V])
+        (using b: BoundedSemiLattice[V]): Map[K, V] =
+    map1 |+| map2
+
+  def total(map: Map[K, V])
+      (using m: CommutativeMonoid[V]): V =
+    map.values.toList.combineAll
 ```
 </div>
 

--- a/src/pages/case-studies/crdt/abstraction.md
+++ b/src/pages/case-studies/crdt/abstraction.md
@@ -79,10 +79,10 @@ in the companion object for `GCounter`
 to place it in global implicit scope:
 
 ```scala mdoc:silent
-import cats.instances.list._   // for Monoid
-import cats.instances.map._    // for Monoid
-import cats.syntax.semigroup._ // for |+|
-import cats.syntax.foldable._  // for combineAll
+import cats.instances.list.*   // for Monoid
+import cats.instances.map.*    // for Monoid
+import cats.syntax.semigroup.* // for |+|
+import cats.syntax.foldable.*  // for combineAll
 
 given mapGCounterInstance[K, V]: GCounter[Map, K, V] with
   def increment(map: Map[K, V])(key: K, value: V)
@@ -104,7 +104,7 @@ given mapGCounterInstance[K, V]: GCounter[Map, K, V] with
 You should be able to use your instance as follows:
 
 ```scala mdoc:silent
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 
 val g1 = Map("a" -> 7, "b" -> 3)
 val g2 = Map("a" -> 2, "b" -> 5)

--- a/src/pages/case-studies/crdt/abstraction.md
+++ b/src/pages/case-studies/crdt/abstraction.md
@@ -174,7 +174,7 @@ With our type class in place we can implement syntax
 to enhance data types for which we have instances:
 
 ```scala mdoc:silent
-implicit class KvsOps[F[_,_], K, V](f: F[K, V]) {
+extension [F[_,_], K, V](f: F[K, V]) {
   def put(key: K, value: V)
         (using kvs: KeyValueStore[F]): F[K, V] =
     kvs.put(f)(key, value)

--- a/src/pages/case-studies/crdt/abstraction.md
+++ b/src/pages/case-studies/crdt/abstraction.md
@@ -206,7 +206,7 @@ using an `implicit def`:
 
 ```scala mdoc:silent
 implicit def gcounterInstance[F[_,_], K, V]
-    (implicit kvs: KeyValueStore[F], km: CommutativeMonoid[F[K, V]]) =
+    (implicit kvs: KeyValueStore[F], km: CommutativeMonoid[F[K, V]]): GCounter[F, K, V] =
   new GCounter[F, K, V] {
     def increment(f: F[K, V])(key: K, value: V)
           (implicit m: CommutativeMonoid[V]): F[K, V] = {

--- a/src/pages/case-studies/crdt/g-counter.md
+++ b/src/pages/case-studies/crdt/g-counter.md
@@ -100,7 +100,7 @@ We can implement a GCounter with the following interface,
 where we represent machine IDs as `Strings`.
 
 ```scala mdoc:reset-object:silent
-final case class GCounter(counters: Map[String, Int]) {
+final case class GCounter(counters: Map[String, Int]):
   def increment(machine: String, amount: Int) =
     ???
 
@@ -109,7 +109,6 @@ final case class GCounter(counters: Map[String, Int]) {
 
   def total: Int =
     ???
-}
 ```
 
 Finish the implementation!
@@ -119,7 +118,7 @@ Hopefully the description above was clear enough that
 you can get to an implementation like the one below.
 
 ```scala mdoc:silent:reset-object
-final case class GCounter(counters: Map[String, Int]) {
+final case class GCounter(counters: Map[String, Int]):
   def increment(machine: String, amount: Int) = {
     val value = amount + counters.getOrElse(machine, 0)
     GCounter(counters + (machine -> value))
@@ -131,8 +130,6 @@ final case class GCounter(counters: Map[String, Int]) {
         k -> (v max that.counters.getOrElse(k, 0))
     })
 
-  def total: Int =
-    counters.values.sum
-}
+  def total: Int = counters.values.sum
 ```
 </div>

--- a/src/pages/case-studies/crdt/generalisation.md
+++ b/src/pages/case-studies/crdt/generalisation.md
@@ -153,14 +153,12 @@ object wrapper {
   }
 
   object BoundedSemiLattice {
-    implicit val intInstance: BoundedSemiLattice[Int] =
-      new BoundedSemiLattice[Int] {
-        def combine(a1: Int, a2: Int): Int =
-          a1 max a2
+    given intInstance: BoundedSemiLattice[Int] with
+      def combine(a1: Int, a2: Int): Int =
+        a1 max a2
 
-        val empty: Int =
-          0
-      }
+      val empty: Int =
+        0
 
     implicit def setInstance[A]: BoundedSemiLattice[Set[A]] =
       new BoundedSemiLattice[Set[A]]{
@@ -203,16 +201,16 @@ import cats.syntax.foldable._  // for combineAll
 
 final case class GCounter[A](counters: Map[String,A]) {
   def increment(machine: String, amount: A)
-        (implicit m: CommutativeMonoid[A]): GCounter[A] = {
+        (using m: CommutativeMonoid[A]): GCounter[A] = {
     val value = amount |+| counters.getOrElse(machine, m.empty)
     GCounter(counters + (machine -> value))
   }
 
   def merge(that: GCounter[A])
-        (implicit b: BoundedSemiLattice[A]): GCounter[A] =
+        (using b: BoundedSemiLattice[A]): GCounter[A] =
     GCounter(this.counters |+| that.counters)
 
-  def total(implicit m: CommutativeMonoid[A]): A =
+  def total(using m: CommutativeMonoid[A]): A =
     this.counters.values.toList.combineAll
 }
 ```

--- a/src/pages/case-studies/crdt/generalisation.md
+++ b/src/pages/case-studies/crdt/generalisation.md
@@ -113,10 +113,9 @@ our own `BoundedSemiLattice` type class.
 ```scala mdoc:silent
 import cats.kernel.CommutativeMonoid
 
-trait BoundedSemiLattice[A] extends CommutativeMonoid[A] {
+trait BoundedSemiLattice[A] extends CommutativeMonoid[A]:
   def combine(a1: A, a2: A): A
   def empty: A
-}
 ```
 
 In the implementation above,
@@ -146,28 +145,26 @@ import cats.kernel.CommutativeMonoid
 ```
 
 ```scala mdoc:silent
-object wrapper {
-  trait BoundedSemiLattice[A] extends CommutativeMonoid[A] {
+object wrapper:
+  trait BoundedSemiLattice[A] extends CommutativeMonoid[A]:
     def combine(a1: A, a2: A): A
     def empty: A
-  }
 
-  object BoundedSemiLattice {
-    given intInstance: BoundedSemiLattice[Int] with
-      def combine(a1: Int, a2: Int): Int =
-        a1 max a2
+  given intInstance: BoundedSemiLattice[Int] with
+    def combine(a1: Int, a2: Int): Int =
+      a1 max a2
 
-      val empty: Int =
-        0
+    val empty: Int =
+      0
 
-    given setInstance[A]: BoundedSemiLattice[Set[A]] with
-      def combine(a1: Set[A], a2: Set[A]): Set[A] =
-        a1 union a2
+  given setInstance[A]: BoundedSemiLattice[Set[A]] with
+    def combine(a1: Set[A], a2: Set[A]): Set[A] =
+      a1 union a2
 
-      val empty: Set[A] =
-        Set.empty[A]
-  }
-}; import wrapper.*
+    val empty: Set[A] =
+      Set.empty[A]
+
+import wrapper.*
 ```
 </div>
 
@@ -197,7 +194,7 @@ import cats.instances.map.*    // for Monoid
 import cats.syntax.semigroup.* // for |+|
 import cats.syntax.foldable.*  // for combineAll
 
-final case class GCounter[A](counters: Map[String,A]) {
+final case class GCounter[A](counters: Map[String,A]):
   def increment(machine: String, amount: A)
         (using m: CommutativeMonoid[A]): GCounter[A] = {
     val value = amount |+| counters.getOrElse(machine, m.empty)
@@ -210,7 +207,6 @@ final case class GCounter[A](counters: Map[String,A]) {
 
   def total(using m: CommutativeMonoid[A]): A =
     this.counters.values.toList.combineAll
-}
 ```
 </div>
 

--- a/src/pages/case-studies/crdt/generalisation.md
+++ b/src/pages/case-studies/crdt/generalisation.md
@@ -160,14 +160,12 @@ object wrapper {
       val empty: Int =
         0
 
-    implicit def setInstance[A]: BoundedSemiLattice[Set[A]] =
-      new BoundedSemiLattice[Set[A]]{
-        def combine(a1: Set[A], a2: Set[A]): Set[A] =
-          a1 union a2
+    given setInstance[A]: BoundedSemiLattice[Set[A]] with
+      def combine(a1: Set[A], a2: Set[A]): Set[A] =
+        a1 union a2
 
-        val empty: Set[A] =
-          Set.empty[A]
-      }
+      val empty: Set[A] =
+        Set.empty[A]
   }
 }; import wrapper._
 ```

--- a/src/pages/case-studies/crdt/generalisation.md
+++ b/src/pages/case-studies/crdt/generalisation.md
@@ -167,7 +167,7 @@ object wrapper {
       val empty: Set[A] =
         Set.empty[A]
   }
-}; import wrapper._
+}; import wrapper.*
 ```
 </div>
 
@@ -192,10 +192,10 @@ which significantly simplifies
 the process of merging and maximising counters:
 
 ```scala mdoc:silent
-import cats.instances.list._   // for Monoid
-import cats.instances.map._    // for Monoid
-import cats.syntax.semigroup._ // for |+|
-import cats.syntax.foldable._  // for combineAll
+import cats.instances.list.*   // for Monoid
+import cats.instances.map.*    // for Monoid
+import cats.syntax.semigroup.* // for |+|
+import cats.syntax.foldable.*  // for combineAll
 
 final case class GCounter[A](counters: Map[String,A]) {
   def increment(machine: String, amount: A)

--- a/src/pages/case-studies/map-reduce/index.md
+++ b/src/pages/case-studies/map-reduce/index.md
@@ -161,14 +161,14 @@ Here's some sample output for reference:
 
 ```scala mdoc:invisible:reset
 import cats.Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.semigroup.* // for |+|
 
 def foldMap[A, B: Monoid](values: Vector[A])(func: A => B): B =
   values.foldLeft(Monoid[B].empty)(_ |+| func(_))
 ```
 
 ```scala mdoc:silent
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 ```
 
 ```scala mdoc
@@ -176,7 +176,7 @@ foldMap(Vector(1, 2, 3))(identity)
 ```
 
 ```scala mdoc:silent
-import cats.instances.string._ // for Monoid
+import cats.instances.string.* // for Monoid
 ```
 
 ```scala mdoc
@@ -194,7 +194,7 @@ as described in Section [@sec:monoid-syntax]:
 
 ```scala mdoc:reset:silent
 import cats.Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.semigroup.* // for |+|
 
 def foldMap[A, B : Monoid](as: Vector[A])(func: A => B): B =
   as.map(func).foldLeft(Monoid[B].empty)(_ |+| _)
@@ -204,7 +204,7 @@ We can make a slight alteration to this code to do everything in one step:
 
 ```scala mdoc:reset:invisible
 import cats.Monoid
-import cats.syntax.semigroup._
+import cats.syntax.semigroup.*
 ```
 ```scala mdoc:silent
 def foldMap[A, B : Monoid](as: Vector[A])(func: A => B): B =
@@ -304,9 +304,9 @@ Future.sequence(List(Future(1), Future(2), Future(3)))
 or an instance of `Traverse`:
 
 ```scala mdoc:silent
-import cats.instances.future._ // for Applicative
-import cats.instances.list._   // for Traverse
-import cats.syntax.traverse._  // for sequence
+import cats.instances.future.* // for Applicative
+import cats.instances.list.*   // for Traverse
+import cats.syntax.traverse.*  // for sequence
 ```
 
 ```scala mdoc
@@ -318,8 +318,8 @@ Finally, we can use `Await.result`
 to block on a `Future` until a result is available:
 
 ```scala mdoc:silent
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 ```
 
 ```scala mdoc
@@ -331,8 +331,8 @@ available from `cats.instances.future`:
 
 ```scala mdoc:silent
 import cats.{Monad, Monoid}
-import cats.instances.int._    // for Monoid
-import cats.instances.future._ // for Monad and Monoid
+import cats.instances.int.*    // for Monoid
+import cats.instances.future.* // for Monad and Monoid
 
 Monad[Future].pure(42)
 
@@ -385,10 +385,10 @@ splits out each `map` and `fold`
 into a separate line of code:
 
 ```scala mdoc:invisible:reset
-import cats._
-import cats.implicits._
-import scala.concurrent._
-import scala.concurrent.duration._
+import cats.*
+import cats.implicits.*
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 ```
 ```scala mdoc:silent
@@ -432,10 +432,10 @@ are actually equivalent to a single call to `foldMap`,
 shortening the entire algorithm as follows:
 
 ```scala mdoc:reset:invisible
-import cats._
-import cats.implicits._
-import scala.concurrent._
-import scala.concurrent.duration._
+import cats.*
+import cats.implicits.*
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 def foldMap[A, B : Monoid](as: Vector[A])(func: A => B): B =
   as.foldLeft(Monoid[B].empty)(_ |+| func(_))
@@ -482,15 +482,15 @@ We'll restate all of the necessary imports for completeness:
 ```scala mdoc:silent:reset
 import cats.Monoid
 
-import cats.instances.int._    // for Monoid
-import cats.instances.future._ // for Applicative and Monad
-import cats.instances.vector._ // for Foldable and Traverse
+import cats.instances.int.*    // for Monoid
+import cats.instances.future.* // for Applicative and Monad
+import cats.instances.vector.* // for Foldable and Traverse
 
-import cats.syntax.foldable._  // for combineAll and foldMap
-import cats.syntax.traverse._  // for traverse
+import cats.syntax.foldable.*  // for combineAll and foldMap
+import cats.syntax.traverse.*  // for traverse
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 ```
 

--- a/src/pages/case-studies/parser/applicative.md
+++ b/src/pages/case-studies/parser/applicative.md
@@ -19,12 +19,10 @@ Define an extension method `flatten`, and an instance of `Flattener` for a neste
 
 <div class="solution">
 ~~~ scala
-extension [A, B, C](in: ((A, B), C)) {
+extension [A, B, C](in: ((A, B), C))
   def flatten: (A, B, C) =
-    in match {
+    in match
       case ((a, b), c) => (a, b, c)
-    }
-}
 ~~~
 
 It's fairly straightforward to define this class, but we can't abstract over it in any way. If we want to define `flatten` for a tuple like `(a, (b, c))` we need to define a new extension method. Similarly if we want to flatten a tuple with four elements.

--- a/src/pages/case-studies/parser/applicative.md
+++ b/src/pages/case-studies/parser/applicative.md
@@ -107,8 +107,8 @@ The method is called `ap` and types `F[A]` that implement it are called **applic
 The Scalaz library provides an applicative functor type class, and instances for `Option` and many other types. In Scalaz, `ap` is written as `<*>` for consistency with Haskell. Here's an example:
 
 ~~~ scala
-import scalaz.syntax.applicative._
-import scalaz.std.option._
+import scalaz.syntax.applicative.*
+import scalaz.std.option.*
 
 val adder = ((x: Int, y: Int, z: Int) => x + y + z).curried
 // adder: Int => (Int => (Int => Int)) = <function1>
@@ -198,7 +198,7 @@ Checkout the `parser-applicative` tag to see the full code and tests.
 Once we have our `Applicative` instance we can take it for a spin:
 
 ~~~ scala
-import scalaz.syntax.applicative._
+import scalaz.syntax.applicative.*
 
 val parser = Parser.string("chicken") <*> ((_: String) => "Tastes like chicken").point[Parser]
 // parser: underscore.parser.Parser[String] = Parser(<function1>)
@@ -258,7 +258,7 @@ Sometime we do need more than one result, so the problem still remains. In these
 Here is it in use
 
 ~~~ scala
-import scalaz.syntax.applicative._
+import scalaz.syntax.applicative.*
 
 def taste(taster: String, action: String, flava: String): String = s"$flava tastes like chicken!"
 // taste: (taster: String, action: String, flava: String)String

--- a/src/pages/case-studies/parser/applicative.md
+++ b/src/pages/case-studies/parser/applicative.md
@@ -15,11 +15,11 @@ Given a nested tuple like `((1, 2), 3)` we could write an implicit conversion to
 
 ### Exercise: Flattening
 
-Define a `Tuple2Flatten` implicit class with an extension method `flatten`, and an instance of `Flattener` for a nested tuple like `((1, 2), 3)`.
+Define an extension method `flatten`, and an instance of `Flattener` for a nested tuple like `((1, 2), 3)`.
 
 <div class="solution">
 ~~~ scala
-implicit class Tuple2Flatten[A, B, C](val in: ((A, B), C)) extends AnyVal {
+extension [A, B, C](in: ((A, B), C)) {
   def flatten: (A, B, C) =
     in match {
       case ((a, b), c) => (a, b, c)

--- a/src/pages/case-studies/parser/applicative.md
+++ b/src/pages/case-studies/parser/applicative.md
@@ -143,13 +143,12 @@ Let's implement an instance of Scalaz's `Applicative` type class for our `Parser
 Define a typeclass instance of `Applicative` for `Parser`. You must implement the following trait:
 
 ~~~ scala
-Applicative[Parser] {
+Applicative[Parser] with
   def point[A](a: => A): Parser[A] =
     ???
 
   def ap[A, B](fa: => Parser[A])(f: => Parser[A => B]): Parser[B] =
     ???
-}
 ~~~
 
 Hints:
@@ -166,25 +165,24 @@ The usual place to define typeclass instances is as implicit elements on the com
 val identity: Parser[Unit] =
   Parser { input => Success(Unit, input) }
 
-implicit object applicativeInstance extends Applicative[Parser] {
+given applicativeInstance: Applicative[Parser] with
   def point[A](a: => A): Parser[A] =
     identity map (_ => a)
 
   def ap[A, B](fa: => Parser[A])(f: => Parser[A => B]): Parser[B] =
     Parser { input =>
-      f.parse(input) match {
+      f.parse(input) match
         case fail @ Failure(_) =>
           fail
         case Success(aToB, remainder) =>
-          fa.parse(remainder) match {
+          fa.parse(remainder) match
             case fail @ Failure(_) =>
               fail
             case Success(a, remainder1) =>
               Success(aToB(a), remainder1)
-          }
-      }
+          end match
+      end match
     }
-}
 ~~~
 
 Checkout the `parser-applicative` tag to see the full code and tests.

--- a/src/pages/case-studies/parser/error-handling.md
+++ b/src/pages/case-studies/parser/error-handling.md
@@ -129,11 +129,8 @@ Implement a parser for digits using the regular expression `"[0-9]"` to match a 
 ~~~ scala
 package underscore.parser
 
-object NumericParser {
-
+object NumericParser:
   val digits = Parser.regex("[0-9]").+
-
-}
 ~~~
 </div>
 
@@ -184,14 +181,11 @@ If `add` was a normal method we'ld only print `"Hi"` once.
 If we make the parameter of `~` and `|` call-by-name, our `Parser` will work. Try it and you'll see another issue---the way the grammar is written we'll stop after parsing the first number. (Try `expression.parse("123+456")` and you'll see.) The solution is to rewrite the grammar so we look for compound expressions first and we proceed left-to-right.
 
 ~~~ scala
-object NumericParser {
-
+object NumericParser:
   val digits = Parser.regex("[0-9]").+
 
   def expression: Parser =
     (digits ~ Parser.string("+") ~ expression) | (digits ~ Parser.string("-") ~ expression) | digits
-
-}
 ~~~
 
 The code is tagged with `parser-numeric-expression`.

--- a/src/pages/case-studies/parser/error-handling.md
+++ b/src/pages/case-studies/parser/error-handling.md
@@ -12,17 +12,16 @@ We will fix this by thinking and coding systematically. The first thing is ask o
 
 Once we make this realisation the code follows straight-away. For this type of data we use the *sealed trait* pattern.
 
-### The Sealed Trait Pattern
+### Enum Pattern
 
 If some data `A` can be a `B` or a `C` and nothing else, we should write
 
 ~~~ scala
-sealed trait A
-final case class B() extends A
-final case class C() extends A
+enum A {
+  case B()
+  case C()
+}
 ~~~
-
-Sealed traits. Extension points (final / non-final)
 
 ### Exercise
 
@@ -35,9 +34,10 @@ Implement a better `ParserResult`. This exercise is deliberately vague about wha
 Here's my implementation. It follows the existing pattern for success, maintaining the `result` and `remainder` fields, but returns an error message on failure. I also renamed `ParseResult` to just `Parse`. With the subtypes it's fairly obvious that a `Parse` is the result of a `Parser`.
 
 ~~~ scala
-sealed trait Parse
-final case class Failure(message: String) extends Parse
-final case class Success(result: String, remainder: String) extends Parse
+enum Parse {
+  case class Failure(message: String)
+  case class Success(result: String, remainder: String)
+}
 ~~~
 </div>
 

--- a/src/pages/case-studies/parser/intro.md
+++ b/src/pages/case-studies/parser/intro.md
@@ -32,18 +32,14 @@ package underscore.parser
 
 import scala.annotation.tailrec
 
-case class ParseResult(result: String, remainder: String) {
-
+case class ParseResult(result: String, remainder: String):
   def failed: Boolean =
     result.isEmpty
 
   def success: Boolean =
     !failed
 
-}
-
-case class Parser(parse: String => ParseResult) {
-
+case class Parser(parse: String => ParseResult):
   def ~(next: Parser): Parser = ???
 
   def `*`: Parser =
@@ -60,10 +56,7 @@ case class Parser(parse: String => ParseResult) {
       loop("", input)
     }
 
-}
-
-object Parser {
-
+object Parser:
   def string(literal: String): Parser =
     Parser { input =>
       if(input.startsWith(literal))
@@ -71,8 +64,6 @@ object Parser {
       else
         ParseResult("", input)
     }
-
-}
 ~~~
 
 What does the code do? The first thing is to look at what a `Parser` is. It is basically a wrapper around a function `String => ParseResult`. The `String` parameter is the input to parse, and returned is the result of parsing that `String`.

--- a/src/pages/case-studies/parser/intro.md
+++ b/src/pages/case-studies/parser/intro.md
@@ -51,12 +51,11 @@ case class Parser(parse: String => ParseResult) {
       @tailrec
       def loop(result: String, remainder: String): ParseResult = {
         val result1 = this.parse(remainder)
-        result1 match {
+        result1 match
           case _ if result1.failed =>
             ParseResult(result, remainder)
           case ParseResult(result1, remainder1) =>
             loop(result + result1, remainder1)
-        }
       }
       loop("", input)
     }
@@ -115,18 +114,18 @@ Checkout the `parser-initial-a` tag to see the complete code with `~` implemente
 def ~(next: Parser): Parser =
   Parser { input =>
     val result = this.parse(input)
-    result match {
+    result match
       case _ if result.failed =>
         result
       case ParseResult(parsed, remainder) =>
         val result1 = next.parse(remainder)
-        result1 match {
+        result1 match
           case _ if result1.failed =>
             ParseResult("", input)
           case ParseResult(parsed1, remainder1) =>
             ParseResult(parsed + parsed1, remainder1)
-        }
-    }
+        end match
+    end match
   }
 ~~~
 </div>

--- a/src/pages/case-studies/parser/transforms.md
+++ b/src/pages/case-studies/parser/transforms.md
@@ -101,10 +101,11 @@ Start by implementing data structures to store the result of a successful parse.
 An expression is an addition, or a substraction, or a number. Once we have this structure its realisation in code is straightforward.
 
 ~~~ scala
-sealed trait Expression
-final case class Addition(left: Expression, right: Expression) extends Expression
-final case class Subtraction(left: Expression, right: Expression) extends Expression
-final case class Number(value: Int) extends Expression
+enum Expression {
+  case Addition(left: Expression, right: Expression)
+  case Subtraction(left: Expression, right: Expression)
+  case Number(value: Int)
+}
 ~~~
 </div>
 
@@ -147,20 +148,10 @@ There are two ways we could write this method: as a method on `Expression` using
 Either way, `eval` is a straightforward application of structural recursion. My implementation is:
 
 ~~~ scala
-sealed trait Expression {
-  def eval: Int
-}
-final case class Addition(left: Expression, right: Expression) extends Expression {
-  def eval: Int =
-    left.eval + right.eval
-}
-final case class Subtraction(left: Expression, right: Expression) extends Expression {
-  def eval: Int =
-    left.eval - right.eval
-}
-final case class Number(value: Int) extends Expression {
-  def eval: Int =
-    value
+enum Expression(val eval: Int) {
+  case Addition(left: Expression, right: Expression) extends Expression(left.eval + right.eval)
+  case Subtraction(left: Expression, right: Expression) extends Expression(left.eval - right.eval)
+  case Number(value: Int) extends Expression(value)
 }
 ~~~
 

--- a/src/pages/case-studies/testing/index.md
+++ b/src/pages/case-studies/testing/index.md
@@ -24,9 +24,9 @@ We'll also have an `UptimeService` that maintains a list of servers
 and allows the user to poll them for their total uptime:
 
 ```scala mdoc:silent
-import cats.instances.future._ // for Applicative
-import cats.instances.list._   // for Traverse
-import cats.syntax.traverse._  // for traverse
+import cats.instances.future.* // for Applicative
+import cats.instances.list.*   // for Traverse
+import cats.syntax.traverse.*  // for traverse
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class UptimeService(client: UptimeClient) {
@@ -268,8 +268,8 @@ to `UptimeService`.
 We can write this as an implicit parameter:
 
 ```scala mdoc:invisible:reset-object
-import cats.syntax.traverse._  // for traverse
-import cats.instances.list._
+import cats.syntax.traverse.*  // for traverse
+import cats.instances.list.*
 
 trait UptimeClient[F[_]] {
   def getUptime(hostname: String): F[Int]
@@ -277,7 +277,7 @@ trait UptimeClient[F[_]] {
 ```
 ```scala mdoc:silent
 import cats.Applicative
-import cats.syntax.functor._ // for map
+import cats.syntax.functor.* // for map
 
 class UptimeService[F[_]](client: UptimeClient[F])
     (using a: Applicative[F]) {
@@ -291,9 +291,9 @@ or more tersely as a context bound:
 
 ```scala mdoc:reset-object:invisible
 import cats.Applicative
-import cats.syntax.functor._
-import cats.syntax.traverse._
-import cats.instances.list._
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import cats.instances.list.*
 
 trait UptimeClient[F[_]] {
   def getUptime(hostname: String): F[Int]
@@ -326,9 +326,9 @@ synchronously without worrying about monads or applicatives:
 
 ```scala mdoc:invisible:reset-object
 import cats.{Id, Applicative}
-import cats.instances.list._  // for Traverse
-import cats.syntax.functor._  // for map
-import cats.syntax.traverse._ // for traverse
+import cats.instances.list.*  // for Traverse
+import cats.syntax.functor.*  // for map
+import cats.syntax.traverse.* // for traverse
 import scala.concurrent.Future
 
 trait UptimeClient[F[_]] {

--- a/src/pages/case-studies/testing/index.md
+++ b/src/pages/case-studies/testing/index.md
@@ -53,7 +53,7 @@ We want to test its ability to sum values,
 regardless of where it is getting them from.
 Here's an example:
 
-```scala mdoc:warn
+```scala mdoc:fail
 def testTotalUptime() = {
   val hosts    = Map("host1" -> 10, "host2" -> 6)
   val client   = new TestUptimeClient(hosts)

--- a/src/pages/case-studies/testing/index.md
+++ b/src/pages/case-studies/testing/index.md
@@ -280,7 +280,7 @@ import cats.Applicative
 import cats.syntax.functor._ // for map
 
 class UptimeService[F[_]](client: UptimeClient[F])
-    (implicit a: Applicative[F]) {
+    (using a: Applicative[F]) {
 
   def getTotalUptime(hostnames: List[String]): F[Int] =
     hostnames.traverse(client.getUptime).map(_.sum)

--- a/src/pages/case-studies/validation/check.md
+++ b/src/pages/case-studies/validation/check.md
@@ -28,11 +28,10 @@ We will probably want to add custom methods to `Check`
 so let's declare it as a `trait` instead of a type alias:
 
 ```scala mdoc:silent:reset-object
-trait Check[E, A] {
+trait Check[E, A]:
   def apply(value: A): Either[E, A]
 
   // other methods...
-}
 ```
 
 As we said in [Essential Scala][link-essential-scala],
@@ -56,12 +55,11 @@ Think about implementing this method now.
 You should hit some problems. Read on when you do!
 
 ```scala mdoc:silent:reset-object
-trait Check[E, A] {
+trait Check[E, A]:
   def and(that: Check[E, A]): Check[E, A] =
     ???
 
   // other methods...
-}
 ```
 
 The problem is: what do you do when *both* checks fail?
@@ -136,7 +134,7 @@ import cats.syntax.semigroup.* // for |+|
 ```
 
 ```scala mdoc:silent
-final case class CheckF[E, A](func: A => Either[E, A]) {
+final case class CheckF[E, A](func: A => Either[E, A]):
   def apply(a: A): Either[E, A] =
     func(a)
 
@@ -150,7 +148,6 @@ final case class CheckF[E, A](func: A => Either[E, A]) {
         case (Right(_), Right(_)) => a.asRight
       }
     }
-}
 ```
 
 Let's test the behaviour we get.
@@ -195,7 +192,7 @@ What happens if we create instances of `CheckF[Nothing, A]`?
 import cats.Semigroup
 import cats.syntax.semigroup.*
 import cats.syntax.either.*
-final case class CheckF[E, A](func: A => Either[E, A]) {
+final case class CheckF[E, A](func: A => Either[E, A]):
   def apply(a: A): Either[E, A] =
     func(a)
 
@@ -209,7 +206,6 @@ final case class CheckF[E, A](func: A => Either[E, A]) {
         case (Right(_), Right(_)) => a.asRight
       }
     }
-}
 ```
 ```scala mdoc:silent
 val a: CheckF[Nothing, Int] =

--- a/src/pages/case-studies/validation/check.md
+++ b/src/pages/case-studies/validation/check.md
@@ -83,8 +83,8 @@ the `combine` method or its associated `|+|` syntax:
 
 ```scala mdoc:silent
 import cats.Semigroup
-import cats.instances.list._   // for Semigroup
-import cats.syntax.semigroup._ // for |+|
+import cats.instances.list.*   // for Semigroup
+import cats.syntax.semigroup.* // for |+|
 
 val semigroup = Semigroup[List[String]]
 ```
@@ -131,8 +131,8 @@ we'll call this implementation `CheckF`:
 
 ```scala mdoc:silent
 import cats.Semigroup
-import cats.syntax.either._    // for asLeft and asRight
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.either.*    // for asLeft and asRight
+import cats.syntax.semigroup.* // for |+|
 ```
 
 ```scala mdoc:silent
@@ -157,7 +157,7 @@ Let's test the behaviour we get.
 First we'll setup some checks:
 
 ```scala mdoc:silent
-import cats.instances.list._ // for Semigroup
+import cats.instances.list.* // for Semigroup
 
 val a: CheckF[List[String], Int] =
   CheckF { v =>
@@ -193,8 +193,8 @@ What happens if we create instances of `CheckF[Nothing, A]`?
 
 ```scala mdoc:invisible:reset-object
 import cats.Semigroup
-import cats.syntax.semigroup._
-import cats.syntax.either._
+import cats.syntax.semigroup.*
+import cats.syntax.either.*
 final case class CheckF[E, A](func: A => Either[E, A]) {
   def apply(a: A): Either[E, A] =
     func(a)
@@ -235,13 +235,13 @@ We'll call this implementation `Check`:
 
 ```scala mdoc:invisible:reset-object
 import cats.Semigroup
-import cats.syntax.either._    // for asLeft and asRight
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.either.*    // for asLeft and asRight
+import cats.syntax.semigroup.* // for |+|
 ```
 
 ```scala mdoc:silent
 sealed trait Check[E, A] {
-  import Check._
+  import Check.*
 
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)
@@ -332,12 +332,12 @@ Here's the complete implementation:
 ```scala mdoc:silent:reset-object
 import cats.Semigroup
 import cats.data.Validated
-import cats.syntax.apply._     // for mapN
+import cats.syntax.apply.*     // for mapN
 ```
 
 ```scala mdoc:silent
 sealed trait Check[E, A] {
-  import Check._
+  import Check.*
 
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)
@@ -375,14 +375,14 @@ is implicit in the semantics of "or".
 ```scala mdoc:silent:reset-object
 import cats.Semigroup
 import cats.data.Validated
-import cats.syntax.semigroup._ // for |+|
-import cats.syntax.apply._     // for mapN
-import cats.data.Validated._   // for Valid and Invalid
+import cats.syntax.semigroup.* // for |+|
+import cats.syntax.apply.*     // for mapN
+import cats.data.Validated.*   // for Valid and Invalid
 ```
 
 ```scala mdoc:silent
 sealed trait Check[E, A] {
-  import Check._
+  import Check.*
 
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)

--- a/src/pages/case-studies/validation/check.md
+++ b/src/pages/case-studies/validation/check.md
@@ -141,7 +141,7 @@ final case class CheckF[E, A](func: A => Either[E, A]) {
     func(a)
 
   def and(that: CheckF[E, A])
-        (implicit s: Semigroup[E]): CheckF[E, A] =
+        (using s: Semigroup[E]): CheckF[E, A] =
     CheckF { a =>
       (this(a), that(a)) match {
         case (Left(e1),  Left(e2))  => (e1 |+| e2).asLeft
@@ -200,7 +200,7 @@ final case class CheckF[E, A](func: A => Either[E, A]) {
     func(a)
 
   def and(that: CheckF[E, A])
-        (implicit s: Semigroup[E]): CheckF[E, A] =
+        (using s: Semigroup[E]): CheckF[E, A] =
     CheckF { a =>
       (this(a), that(a)) match {
         case (Left(e1),  Left(e2))  => (e1 |+| e2).asLeft
@@ -246,7 +246,7 @@ sealed trait Check[E, A] {
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)
 
-  def apply(a: A)(implicit s: Semigroup[E]): Either[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Either[E, A] =
     this match {
       case Pure(func) =>
         func(a)
@@ -342,7 +342,7 @@ sealed trait Check[E, A] {
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
     this match {
       case Pure(func) =>
         func(a)
@@ -390,7 +390,7 @@ sealed trait Check[E, A] {
   def or(that: Check[E, A]): Check[E, A] =
     Or(this, that)
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
     this match {
       case Pure(func) =>
         func(a)

--- a/src/pages/case-studies/validation/check.md
+++ b/src/pages/case-studies/validation/check.md
@@ -240,14 +240,14 @@ import cats.syntax.semigroup.* // for |+|
 ```
 
 ```scala mdoc:silent
-sealed trait Check[E, A] {
+sealed trait Check[E, A]:
   import Check.*
 
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)
 
   def apply(a: A)(using s: Semigroup[E]): Either[E, A] =
-    this match {
+    this match
       case Pure(func) =>
         func(a)
 
@@ -258,9 +258,9 @@ sealed trait Check[E, A] {
           case (Right(_),  Left(e))   => e.asLeft
           case (Right(_), Right(_)) => a.asRight
         }
-    }
-}
-object Check {
+    end match
+
+object Check:
   final case class And[E, A](
     left: Check[E, A],
     right: Check[E, A]) extends Check[E, A]
@@ -270,7 +270,6 @@ object Check {
     
   def pure[E, A](f: A => Either[E, A]): Check[E, A] =
     Pure(f)
-}
 ```
 
 Let's see an example:
@@ -336,29 +335,27 @@ import cats.syntax.apply.*     // for mapN
 ```
 
 ```scala mdoc:silent
-sealed trait Check[E, A] {
+sealed trait Check[E, A]:
   import Check.*
 
   def and(that: Check[E, A]): Check[E, A] =
     And(this, that)
 
   def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
-    this match {
+    this match
       case Pure(func) =>
         func(a)
 
       case And(left, right) =>
         (left(a), right(a)).mapN((_, _) => a)
-    }
-}
-object Check {
+
+object Check:
   final case class And[E, A](
     left: Check[E, A],
     right: Check[E, A]) extends Check[E, A]
   
   final case class Pure[E, A](
     func: A => Validated[E, A]) extends Check[E, A]
-}
 ```
 </div>
 
@@ -381,7 +378,7 @@ import cats.data.Validated.*   // for Valid and Invalid
 ```
 
 ```scala mdoc:silent
-sealed trait Check[E, A] {
+sealed trait Check[E, A]:
   import Check.*
 
   def and(that: Check[E, A]): Check[E, A] =
@@ -391,7 +388,7 @@ sealed trait Check[E, A] {
     Or(this, that)
 
   def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
-    this match {
+    this match
       case Pure(func) =>
         func(a)
 
@@ -407,9 +404,9 @@ sealed trait Check[E, A] {
               case Invalid(e2) => Invalid(e1 |+| e2)
             }
         }
-    }
-}
-object Check {
+    end match
+
+object Check:
   final case class And[E, A](
     left: Check[E, A],
     right: Check[E, A]) extends Check[E, A]
@@ -420,7 +417,6 @@ object Check {
   
   final case class Pure[E, A](
     func: A => Validated[E, A]) extends Check[E, A]
-}
 ```
 </div>
 

--- a/src/pages/case-studies/validation/kleisli.md
+++ b/src/pages/case-studies/validation/kleisli.md
@@ -125,7 +125,7 @@ Like `apply`, the method must accept an implicit `Semigroup`:
 import cats.Semigroup
 import cats.data.Validated
 
-sealed trait Predicate[E, A] {
+sealed trait Predicate[E, A]:
   def run(using s: Semigroup[E]): A => Either[E, A] =
     (a: A) => this(a).toEither
 
@@ -133,7 +133,6 @@ sealed trait Predicate[E, A] {
     ??? // etc...
 
   // other methods...
-}
 ```
 </div>
 

--- a/src/pages/case-studies/validation/kleisli.md
+++ b/src/pages/case-studies/validation/kleisli.md
@@ -330,7 +330,7 @@ def createUser(
       email: String): Either[Errors, User] = (
   checkUsername.run(username),
   checkEmail.run(email)
-).mapN(User)
+).mapN(User.apply)
 ```
 
 ```scala mdoc

--- a/src/pages/case-studies/validation/kleisli.md
+++ b/src/pages/case-studies/validation/kleisli.md
@@ -65,7 +65,7 @@ through three steps:
 
 ```scala mdoc:silent
 import cats.data.Kleisli
-import cats.instances.list._ // for Monad
+import cats.instances.list.* // for Monad
 ```
 
 These steps each transform an input `Int`
@@ -172,13 +172,13 @@ def checkPred[A](pred: Predicate[Errors, A]): Check[A, A] =
 // Foreword declarations
 
 import cats.Semigroup
-import cats.syntax.apply._     // for mapN
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.apply.*     // for mapN
+import cats.syntax.semigroup.* // for |+|
 import cats.data.Validated
 import cats.data.Validated.{Valid, Invalid}
 
 sealed trait Predicate[E, A] {
-  import Predicate._
+  import Predicate.*
 
   def and(that: Predicate[E, A]): Predicate[E, A] =
     And(this, that)
@@ -237,7 +237,7 @@ simplifies things, but the process is still complex:
 
 ```scala mdoc:silent
 import cats.data.{Kleisli, NonEmptyList}
-import cats.instances.either._   // for Semigroupal
+import cats.instances.either.*   // for Semigroupal
 ```
 
 Here is the preamble we suggested in

--- a/src/pages/case-studies/validation/kleisli.md
+++ b/src/pages/case-studies/validation/kleisli.md
@@ -126,7 +126,7 @@ import cats.Semigroup
 import cats.data.Validated
 
 sealed trait Predicate[E, A] {
-  def run(implicit s: Semigroup[E]): A => Either[E, A] =
+  def run(using s: Semigroup[E]): A => Either[E, A] =
     (a: A) => this(a).toEither
 
   def apply(a: A): Validated[E, A] =
@@ -186,10 +186,10 @@ sealed trait Predicate[E, A] {
   def or(that: Predicate[E, A]): Predicate[E, A] =
     Or(this, that)
 
-  def run(implicit s: Semigroup[E]): A => Either[E, A] =
+  def run(using s: Semigroup[E]): A => Either[E, A] =
     (a: A) => this(a).toEither
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
     this match {
       case Pure(func) =>
         func(a)

--- a/src/pages/case-studies/validation/kleisli.md
+++ b/src/pages/case-studies/validation/kleisli.md
@@ -177,7 +177,7 @@ import cats.syntax.semigroup.* // for |+|
 import cats.data.Validated
 import cats.data.Validated.{Valid, Invalid}
 
-sealed trait Predicate[E, A] {
+sealed trait Predicate[E, A]:
   import Predicate.*
 
   def and(that: Predicate[E, A]): Predicate[E, A] =
@@ -190,7 +190,7 @@ sealed trait Predicate[E, A] {
     (a: A) => this(a).toEither
 
   def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
-    this match {
+    this match
       case Pure(func) =>
         func(a)
 
@@ -206,10 +206,10 @@ sealed trait Predicate[E, A] {
               case Invalid(e2) => Invalid(e1 |+| e2)
             }
         }
-    }
-}
+    end match
+end Predicate
 
-object Predicate {
+object Predicate:
   final case class And[E, A](
     left: Predicate[E, A],
     right: Predicate[E, A]) extends Predicate[E, A]
@@ -226,7 +226,7 @@ object Predicate {
 
   def lift[E, A](error: E, func: A => Boolean): Predicate[E, A] =
     Pure(a => if(func(a)) Valid(a) else Invalid(error))
-}
+end Predicate
 ```
 
 Working around limitations of type inference

--- a/src/pages/case-studies/validation/map.md
+++ b/src/pages/case-studies/validation/map.md
@@ -89,9 +89,9 @@ Making this change gives us the following code:
 ```scala mdoc:silent
 import cats.Semigroup
 import cats.data.Validated
-import cats.syntax.semigroup._ // for |+|
-import cats.syntax.apply._     // for mapN
-import cats.data.Validated._   // for Valid and Invalid
+import cats.syntax.semigroup.* // for |+|
+import cats.syntax.apply.*     // for mapN
+import cats.data.Validated.*   // for Valid and Invalid
 ```
 
 ```scala mdoc:silent
@@ -158,11 +158,11 @@ you should be able to create code similar to the below:
 ```scala mdoc:invisible:reset-object
 import cats.Semigroup
 import cats.data.Validated
-import cats.implicits._
+import cats.implicits.*
 
 sealed trait Predicate[E, A] {
-  import Predicate._
-  import Validated._
+  import Predicate.*
+  import Validated.*
 
   def and(that: Predicate[E, A]): Predicate[E, A] =
     And(this, that)
@@ -209,7 +209,7 @@ import cats.data.Validated
 
 ```scala mdoc:silent
 sealed trait Check[E, A, B] {
-  import Check._
+  import Check.*
 
   def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
@@ -373,10 +373,10 @@ including some tidying and repackaging of the code:
 ```scala mdoc:silent:reset-object
 import cats.Semigroup
 import cats.data.Validated
-import cats.data.Validated._   // for Valid and Invalid
-import cats.syntax.semigroup._ // for |+|
-import cats.syntax.apply._     // for mapN
-import cats.syntax.validated._ // for valid and invalid
+import cats.data.Validated.*   // for Valid and Invalid
+import cats.syntax.semigroup.* // for |+|
+import cats.syntax.apply.*     // for mapN
+import cats.syntax.validated.* // for valid and invalid
 ```
 
 Here is our complete implementation of `Predicate`,
@@ -386,8 +386,8 @@ a `Predicate` from a function:
 
 ```scala mdoc:silent
 sealed trait Predicate[E, A] {
-  import Predicate._
-  import Validated._
+  import Predicate.*
+  import Validated.*
 
   def and(that: Predicate[E, A]): Predicate[E, A] =
     And(this, that)
@@ -444,12 +444,12 @@ using inheritance:
 ```scala mdoc:silent
 import cats.Semigroup
 import cats.data.Validated
-import cats.syntax.apply._     // for mapN
-import cats.syntax.validated._ // for valid and invalid
+import cats.syntax.apply.*     // for mapN
+import cats.syntax.validated.* // for valid and invalid
 ```
 ```scala mdoc:silent
 sealed trait Check[E, A, B] {
-  import Check._
+  import Check.*
 
   def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
@@ -589,8 +589,8 @@ In later sections we'll make some changes
 that make the library easier to use.
 
 ```scala mdoc:silent
-import cats.syntax.apply._     // for mapN
-import cats.syntax.validated._ // for valid and invalid
+import cats.syntax.apply.*     // for mapN
+import cats.syntax.validated.* // for valid and invalid
 ```
 
 Here's the implementation of `checkUsername`:

--- a/src/pages/case-studies/validation/map.md
+++ b/src/pages/case-studies/validation/map.md
@@ -647,7 +647,7 @@ final case class User(username: String, email: String)
 def createUser(
       username: String,
       email: String): Validated[Errors, User] =
-  (checkUsername(username), checkEmail(email)).mapN(User)
+  (checkUsername(username), checkEmail(email)).mapN(User.apply)
 ```
 
 We can check our work by creating

--- a/src/pages/case-studies/validation/map.md
+++ b/src/pages/case-studies/validation/map.md
@@ -205,35 +205,32 @@ import cats.data.Validated
 ```
 
 ```scala mdoc:silent
-sealed trait Check[E, A, B] {
+sealed trait Check[E, A, B]:
   import Check.*
 
   def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def map[C](f: B => C): Check[E, A, C] =
     Map[E, A, B, C](this, f)
-}
 
-object Check {
+object Check:
   final case class Map[E, A, B, C](
     check: Check[E, A, B],
-    func: B => C) extends Check[E, A, C] {
+    func: B => C) extends Check[E, A, C]:
   
     def apply(in: A)(using s: Semigroup[E]): Validated[E, C] =
       check(in).map(func)
-  }
+  end Map
   
   final case class Pure[E, A](
-    pred: Predicate[E, A]) extends Check[E, A, A] {
+    pred: Predicate[E, A]) extends Check[E, A, A]:
   
     def apply(in: A)(using s: Semigroup[E]): Validated[E, A] =
       pred(in)
-  }
+  end Pure
 
   def apply[E, A](pred: Predicate[E, A]): Check[E, A, A] =
     Pure(pred)
-}
-
 ```
 </div>
 
@@ -285,22 +282,20 @@ import cats.data.Validated
 ```
 
 ```scala mdoc:silent
-sealed trait Check[E, A, B] {
+sealed trait Check[E, A, B]:
   def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def flatMap[C](f: B => Check[E, A, C]) =
     FlatMap[E, A, B, C](this, f)
 
   // other methods...
-}
 
 final case class FlatMap[E, A, B, C](
   check: Check[E, A, B],
-  func: B => Check[E, A, C]) extends Check[E, A, C] {
+  func: B => Check[E, A, C]) extends Check[E, A, C]:
 
   def apply(a: A)(using s: Semigroup[E]): Validated[E, C] =
     check(a).withEither(_.flatMap(b => func(b)(a).toEither))
-}
 
 // other data types...
 ```
@@ -322,9 +317,8 @@ A `Check` is basically a function `A => Validated[E, B]`
 so we can define an analagous `andThen` method:
 
 ```scala
-trait Check[E, A, B] {
+trait Check[E, A, B]:
   def andThen[C](that: Check[E, B, C]): Check[E, A, C]
-}
 ```
 
 Implement `andThen` now!
@@ -338,20 +332,18 @@ import cats.Semigroup
 import cats.data.Validated
 ```
 ```scala mdoc:silent
-sealed trait Check[E, A, B] {
+sealed trait Check[E, A, B]:
   def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def andThen[C](that: Check[E, B, C]): Check[E, A, C] =
     AndThen[E, A, B, C](this, that)
-}
 
 final case class AndThen[E, A, B, C](
   check1: Check[E, A, B],
-  check2: Check[E, B, C]) extends Check[E, A, C] {
+  check2: Check[E, B, C]) extends Check[E, A, C]:
 
   def apply(a: A)(using s: Semigroup[E]): Validated[E, C] =
     check1(a).withEither(_.flatMap(b => check2(b).toEither))
-}
 ```
 </div>
 

--- a/src/pages/case-studies/validation/map.md
+++ b/src/pages/case-studies/validation/map.md
@@ -102,7 +102,7 @@ sealed trait Predicate[E, A] {
   def or(that: Predicate[E, A]): Predicate[E, A] =
     Or(this, that)
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
     this match {
       case Pure(func) =>
         func(a)
@@ -170,7 +170,7 @@ sealed trait Predicate[E, A] {
   def or(that: Predicate[E, A]): Predicate[E, A] =
     Or(this, that)
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
     this match {
       case Pure(func) =>
         func(a)
@@ -211,7 +211,7 @@ import cats.data.Validated
 sealed trait Check[E, A, B] {
   import Check._
 
-  def apply(in: A)(implicit s: Semigroup[E]): Validated[E, B]
+  def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def map[C](f: B => C): Check[E, A, C] =
     Map[E, A, B, C](this, f)
@@ -222,14 +222,14 @@ object Check {
     check: Check[E, A, B],
     func: B => C) extends Check[E, A, C] {
   
-    def apply(in: A)(implicit s: Semigroup[E]): Validated[E, C] =
+    def apply(in: A)(using s: Semigroup[E]): Validated[E, C] =
       check(in).map(func)
   }
   
   final case class Pure[E, A](
     pred: Predicate[E, A]) extends Check[E, A, A] {
   
-    def apply(in: A)(implicit s: Semigroup[E]): Validated[E, A] =
+    def apply(in: A)(using s: Semigroup[E]): Validated[E, A] =
       pred(in)
   }
 
@@ -289,7 +289,7 @@ import cats.data.Validated
 
 ```scala mdoc:silent
 sealed trait Check[E, A, B] {
-  def apply(in: A)(implicit s: Semigroup[E]): Validated[E, B]
+  def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def flatMap[C](f: B => Check[E, A, C]) =
     FlatMap[E, A, B, C](this, f)
@@ -301,7 +301,7 @@ final case class FlatMap[E, A, B, C](
   check: Check[E, A, B],
   func: B => Check[E, A, C]) extends Check[E, A, C] {
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, C] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, C] =
     check(a).withEither(_.flatMap(b => func(b)(a).toEither))
 }
 
@@ -342,7 +342,7 @@ import cats.data.Validated
 ```
 ```scala mdoc:silent
 sealed trait Check[E, A, B] {
-  def apply(in: A)(implicit s: Semigroup[E]): Validated[E, B]
+  def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def andThen[C](that: Check[E, B, C]): Check[E, A, C] =
     AndThen[E, A, B, C](this, that)
@@ -352,7 +352,7 @@ final case class AndThen[E, A, B, C](
   check1: Check[E, A, B],
   check2: Check[E, B, C]) extends Check[E, A, C] {
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, C] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, C] =
     check1(a).withEither(_.flatMap(b => check2(b).toEither))
 }
 ```
@@ -395,7 +395,7 @@ sealed trait Predicate[E, A] {
   def or(that: Predicate[E, A]): Predicate[E, A] =
     Or(this, that)
 
-  def apply(a: A)(implicit s: Semigroup[E]): Validated[E, A] =
+  def apply(a: A)(using s: Semigroup[E]): Validated[E, A] =
     this match {
       case Pure(func) =>
         func(a)
@@ -451,7 +451,7 @@ import cats.syntax.validated._ // for valid and invalid
 sealed trait Check[E, A, B] {
   import Check._
 
-  def apply(in: A)(implicit s: Semigroup[E]): Validated[E, B]
+  def apply(in: A)(using s: Semigroup[E]): Validated[E, B]
 
   def map[C](f: B => C): Check[E, A, C] =
     Map[E, A, B, C](this, f)
@@ -469,7 +469,7 @@ object Check {
     func: B => C) extends Check[E, A, C] {
 
     def apply(a: A)
-        (implicit s: Semigroup[E]): Validated[E, C] =
+        (using s: Semigroup[E]): Validated[E, C] =
       check(a) map func
   }
 
@@ -478,7 +478,7 @@ object Check {
     func: B => Check[E, A, C]) extends Check[E, A, C] {
 
     def apply(a: A)
-        (implicit s: Semigroup[E]): Validated[E, C] =
+        (using s: Semigroup[E]): Validated[E, C] =
       check(a).withEither(_.flatMap(b => func(b)(a).toEither))
   }
 
@@ -487,7 +487,7 @@ object Check {
     next: Check[E, B, C]) extends Check[E, A, C] {
 
     def apply(a: A)
-        (implicit s: Semigroup[E]): Validated[E, C] =
+        (using s: Semigroup[E]): Validated[E, C] =
       check(a).withEither(_.flatMap(b => next(b).toEither))
   }
 
@@ -495,7 +495,7 @@ object Check {
     func: A => Validated[E, B]) extends Check[E, A, B] {
 
     def apply(a: A)
-        (implicit s: Semigroup[E]): Validated[E, B] =
+        (using s: Semigroup[E]): Validated[E, B] =
       func(a)
   }
 
@@ -503,7 +503,7 @@ object Check {
     pred: Predicate[E, A]) extends Check[E, A, A] {
 
     def apply(a: A)
-        (implicit s: Semigroup[E]): Validated[E, A] =
+        (using s: Semigroup[E]): Validated[E, A] =
       pred(a)
   }
 

--- a/src/pages/foldable-traverse/foldable-cats.md
+++ b/src/pages/foldable-traverse/foldable-cats.md
@@ -13,7 +13,7 @@ Here is an example using `List`:
 
 ```scala mdoc:silent
 import cats.Foldable
-import cats.instances.list._ // for Foldable
+import cats.instances.list.* // for Foldable
 
 val ints = List(1, 2, 3)
 ```
@@ -27,7 +27,7 @@ Here is an example using `Option`,
 which is treated like a sequence of zero or one elements:
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Foldable
+import cats.instances.option.* // for Foldable
 
 val maybeInt = Option(123)
 ```
@@ -73,7 +73,7 @@ Using `Foldable` forces us to use stack safe operations,
 which fixes the overflow exception:
 
 ```scala mdoc:silent
-import cats.instances.lazyList._ // for Foldable
+import cats.instances.lazyList.* // for Foldable
 ```
 
 ```scala mdoc:silent
@@ -130,7 +130,7 @@ Cats provides two methods that make use of `Monoids`:
 For example, we can use `combineAll` to sum over a `List[Int]`:
 
 ```scala mdoc:silent
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 ```
 
 ```scala mdoc
@@ -141,7 +141,7 @@ Alternatively, we can use `foldMap`
 to convert each `Int` to a `String` and concatenate them:
 
 ```scala mdoc:silent
-import cats.instances.string._ // for Monoid
+import cats.instances.string.* // for Monoid
 ```
 
 ```scala mdoc
@@ -153,12 +153,12 @@ to support deep traversal of nested sequences:
 
 ```scala mdoc:invisible:reset-object
 import cats.Foldable
-import cats.instances.list._
-import cats.instances.int._
-import cats.instances.string._
+import cats.instances.list.*
+import cats.instances.int.*
+import cats.instances.string.*
 ```
 ```scala mdoc:silent
-import cats.instances.vector._ // for Monoid
+import cats.instances.vector.* // for Monoid
 
 val ints = List(Vector(1, 2, 3), Vector(4, 5, 6))
 ```
@@ -175,7 +175,7 @@ In each case, the first argument to the method on `Foldable`
 becomes the receiver of the method call:
 
 ```scala mdoc:silent
-import cats.syntax.foldable._ // for combineAll and foldMap
+import cats.syntax.foldable.* // for combineAll and foldMap
 ```
 
 ```scala mdoc

--- a/src/pages/foldable-traverse/foldable.md
+++ b/src/pages/foldable-traverse/foldable.md
@@ -159,7 +159,7 @@ def sumWithMonoid[A](list: List[A])
       (using monoid: Monoid[A]): A =
   list.foldRight(monoid.empty)(monoid.combine)
 
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 ```
 
 ```scala mdoc

--- a/src/pages/foldable-traverse/foldable.md
+++ b/src/pages/foldable-traverse/foldable.md
@@ -141,7 +141,7 @@ one using `scala.math.Numeric`
 import scala.math.Numeric
 
 def sumWithNumeric[A](list: List[A])
-      (implicit numeric: Numeric[A]): A =
+      (using numeric: Numeric[A]): A =
   list.foldRight(numeric.zero)(numeric.plus)
 ```
 
@@ -156,7 +156,7 @@ and one using `cats.Monoid`
 import cats.Monoid
 
 def sumWithMonoid[A](list: List[A])
-      (implicit monoid: Monoid[A]): A =
+      (using monoid: Monoid[A]): A =
   list.foldRight(monoid.empty)(monoid.combine)
 
 import cats.instances.int._ // for Monoid

--- a/src/pages/foldable-traverse/traverse-cats.md
+++ b/src/pages/foldable-traverse/traverse-cats.md
@@ -74,8 +74,8 @@ import cats.syntax.traverse._ // for sequence and traverse
 ```
 
 ```scala mdoc
-Await.result(hostnames.traverse(getUptime), 1.second)
-Await.result(numbers.sequence, 1.second)
+Await.result(hostnames.traverse[Future, Int](getUptime), 1.second)
+Await.result(numbers.sequence[Future, Int], 1.second)
 ```
 
 As you can see, this is much more compact and readable

--- a/src/pages/foldable-traverse/traverse-cats.md
+++ b/src/pages/foldable-traverse/traverse-cats.md
@@ -28,8 +28,8 @@ and use the `traverse` and `sequence` methods
 as described in the previous section:
 
 ```scala mdoc:invisible
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 
 val hostnames = List(
@@ -44,8 +44,8 @@ def getUptime(hostname: String): Future[Int] =
 
 ```scala mdoc:silent
 import cats.Traverse
-import cats.instances.future._ // for Applicative
-import cats.instances.list._   // for Traverse
+import cats.instances.future.* // for Applicative
+import cats.instances.list.*   // for Traverse
 
 val totalUptime: Future[List[Int]] =
   Traverse[List].traverse(hostnames)(getUptime)
@@ -70,7 +70,7 @@ There are also syntax versions of the methods,
 imported via [`cats.syntax.traverse`][cats.syntax.traverse]:
 
 ```scala mdoc:silent
-import cats.syntax.traverse._ // for sequence and traverse
+import cats.syntax.traverse.* // for sequence and traverse
 ```
 
 ```scala mdoc

--- a/src/pages/foldable-traverse/traverse-cats.md
+++ b/src/pages/foldable-traverse/traverse-cats.md
@@ -10,14 +10,13 @@ Here's the abbreviated definition:
 ```scala
 package cats
 
-trait Traverse[F[_]] {
+trait Traverse[F[_]]:
   def traverse[G[_]: Applicative, A, B]
       (inputs: F[A])(func: A => G[B]): G[F[B]]
 
   def sequence[G[_]: Applicative, B]
       (inputs: F[G[B]]): G[F[B]] =
     traverse(inputs)(identity)
-}
 ```
 
 Cats provides instances of `Traverse`

--- a/src/pages/foldable-traverse/traverse.md
+++ b/src/pages/foldable-traverse/traverse.md
@@ -113,12 +113,11 @@ that assumes we're starting with a `List[Future[B]]`
 and don't need to provide an identity function:
 
 ```scala
-object Future {
+object Future:
   def sequence[B](futures: List[Future[B]]): Future[List[B]] =
     traverse(futures)(identity)
 
   // etc...
-}
 ```
 
 In this case the intuitive understanding is even simpler:

--- a/src/pages/foldable-traverse/traverse.md
+++ b/src/pages/foldable-traverse/traverse.md
@@ -16,8 +16,8 @@ As an example, suppose we have a list of server hostnames
 and a method to poll a host for its uptime:
 
 ```scala mdoc:silent
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 
 val hostnames = List(
@@ -62,8 +62,8 @@ We can improve on things greatly using `Future.traverse`,
 which is tailor-made for this pattern:
 
 ```scala mdoc:invisible:reset-object
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 
 val hostnames = List(
@@ -157,8 +157,8 @@ is equivalent to `Applicative.pure`:
 
 ```scala mdoc:silent
 import cats.Applicative
-import cats.instances.future._   // for Applicative
-import cats.syntax.applicative._ // for pure
+import cats.instances.future.*   // for Applicative
+import cats.syntax.applicative.* // for pure
 
 List.empty[Int].pure[Future]
 ```
@@ -181,7 +181,7 @@ def oldCombine(
 is now equivalent to `Semigroupal.combine`:
 
 ```scala mdoc:silent
-import cats.syntax.apply._ // for mapN
+import cats.syntax.apply.* // for mapN
 
 // Combining accumulator and hostname using an Applicative:
 def newCombine(accum: Future[List[Int]],
@@ -223,7 +223,7 @@ as shown in the following exercises.
 What is the result of the following?
 
 ```scala mdoc:silent
-import cats.instances.vector._ // for Applicative
+import cats.instances.vector.* // for Applicative
 
 listSequence(List(Vector(1, 2), Vector(3, 4)))
 ```
@@ -263,7 +263,7 @@ listSequence(List(Vector(1, 2), Vector(3, 4), Vector(5, 6)))
 Here's an example that uses `Options`:
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Applicative
+import cats.instances.option.* // for Applicative
 
 def process(inputs: List[Int]) =
   listTraverse(inputs)(n => if(n % 2 == 0) Some(n) else None)
@@ -297,8 +297,8 @@ Finally, here is an example that uses `Validated`:
 
 ```scala mdoc:invisible:reset
 import cats.Applicative
-import cats.syntax.applicative._ // for pure
-import cats.syntax.apply._ // for mapN
+import cats.syntax.applicative.* // for pure
+import cats.syntax.apply.* // for mapN
 def listTraverse[F[_]: Applicative, A, B]
       (list: List[A])(func: A => F[B]): F[List[B]] =
   list.foldLeft(List.empty[B].pure[F]) { (accum, item) =>
@@ -307,7 +307,7 @@ def listTraverse[F[_]: Applicative, A, B]
 ```
 ```scala mdoc:silent
 import cats.data.Validated
-import cats.instances.list._ // for Monoid
+import cats.instances.list.* // for Monoid
 
 type ErrorsOr[A] = Validated[List[String], A]
 

--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -101,7 +101,7 @@ the `map` method in `cats.syntax.functor`.
 Here's a simplified version of the code:
 
 ```scala
-implicit class FunctorOps[F[_], A](src: F[A]) {
+extension [F[_], A](src: F[A]) {
   def map[B](func: A => B)
       (using functor: Functor[F]): F[B] =
     functor.map(src)(func)

--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -200,12 +200,10 @@ Write a `Functor` for the following binary tree data type.
 Verify that the code works as expected on instances of `Branch` and `Leaf`:
 
 ```scala mdoc:silent
-sealed trait Tree[+A]
-
-final case class Branch[A](left: Tree[A], right: Tree[A])
-  extends Tree[A]
-
-final case class Leaf[A](value: A) extends Tree[A]
+enum Tree[+A] {
+  case Branch[A](left: Tree[A], right: Tree[A]) extends Tree[A]
+  case Leaf[A](value: A) extends Tree[A]
+}
 ```
 
 <div class="solution">
@@ -216,6 +214,7 @@ with the same pattern of `Branch` and `Leaf` nodes:
 
 ```scala mdoc:silent
 import cats.Functor
+import Tree.{Branch, Leaf}
 
 given treeFunctor: Functor[Tree] with
   def map[A, B](tree: Tree[A])(func: A => B): Tree[B] =

--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -152,7 +152,7 @@ given optionFunctor: Functor[Option] with
 Sometimes we need to inject dependencies into our instances.
 For example, if we had to define a custom `Functor` for `Future`
 (another hypothetical example---Cats provides one in `cats.instances.future`)
-we would need to account for the implicit `ExecutionContext` parameter on `future.map`.
+we would need to account for the using clause `ExecutionContext` parameter on `future.map`.
 We can't add extra parameters to `functor.map`
 so we have to account for the dependency when we create the instance:
 
@@ -167,7 +167,7 @@ given futureFunctor(using ec: ExecutionContext): Functor[Future] with
 Whenever we summon a `Functor` for `Future`,
 either directly using `Functor.apply`
 or indirectly via the `map` extension method,
-the compiler will locate `futureFunctor` by implicit resolution
+the compiler will locate `futureFunctor` by given instance resolution
 and recursively search for an `ExecutionContext` at the call site.
 This is what the expansion might look like:
 

--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -14,8 +14,8 @@ the [`cats.instances`][cats.instances] package:
 
 ```scala mdoc:silent:reset-object
 import cats.Functor
-import cats.instances.list._   // for Functor
-import cats.instances.option._ // for Functor
+import cats.instances.list.*   // for Functor
+import cats.instances.option.* // for Functor
 ```
 
 ```scala mdoc
@@ -60,8 +60,8 @@ Scala's `Function1` type doesn't have a `map` method
 so there are no naming conflicts:
 
 ```scala mdoc:silent
-import cats.instances.function._ // for Functor
-import cats.syntax.functor._     // for map
+import cats.instances.function.* // for Functor
+import cats.syntax.functor.*     // for map
 ```
 
 ```scala mdoc:silent
@@ -86,8 +86,8 @@ def doMath[F[_]](start: F[Int])
     (using functor: Functor[F]): F[Int] =
   start.map(n => n + 1 * 2)
 
-import cats.instances.option._ // for Functor
-import cats.instances.list._   // for Functor
+import cats.instances.option.* // for Functor
+import cats.instances.list.*   // for Functor
 ```
 
 ```scala mdoc

--- a/src/pages/functors/cats.md
+++ b/src/pages/functors/cats.md
@@ -205,12 +205,11 @@ import Tree.{Branch, Leaf}
 
 given treeFunctor: Functor[Tree] with
   def map[A, B](tree: Tree[A])(func: A => B): Tree[B] =
-    tree match {
+    tree match
       case Branch(left, right) =>
         Branch(map(left)(func), map(right)(func))
       case Leaf(value) =>
         Leaf(func(value))
-    }
 ```
 
 Let's use our `Functor` to transform some `Trees`:

--- a/src/pages/functors/contravariant-invariant-cats.md
+++ b/src/pages/functors/contravariant-invariant-cats.md
@@ -10,13 +10,11 @@ Here's a simplified version of the code:
 ```
 
 ```scala mdoc:silent
-trait Contravariant[F[_]] {
+trait Contravariant[F[_]]:
   def contramap[A, B](fa: F[A])(f: B => A): F[B]
-}
 
-trait Invariant[F[_]] {
+trait Invariant[F[_]]:
   def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B]
-}
 ```
 
 ### Contravariant in Cats
@@ -67,10 +65,9 @@ If you recall, this is what `Monoid` looks like:
 ```scala
 package cats
 
-trait Monoid[A] {
+trait Monoid[A]:
   def empty: A
   def combine(x: A, y: A): A
-}
 ```
 
 Imagine we want to produce a `Monoid`

--- a/src/pages/functors/contravariant-invariant-cats.md
+++ b/src/pages/functors/contravariant-invariant-cats.md
@@ -99,7 +99,7 @@ import cats.instances.string._ // for Monoid
 import cats.syntax.invariant._ // for imap
 import cats.syntax.semigroup._ // for |+|
 
-implicit val symbolMonoid: Monoid[Symbol] =
+given symbolMonoid: Monoid[Symbol] =
   Monoid[String].imap(Symbol.apply)(_.name)
 ```
 

--- a/src/pages/functors/contravariant-invariant-cats.md
+++ b/src/pages/functors/contravariant-invariant-cats.md
@@ -30,7 +30,7 @@ Here's an example:
 ```scala mdoc:silent:reset
 import cats.Contravariant
 import cats.Show
-import cats.instances.string._
+import cats.instances.string.*
 
 val showString = Show[String]
 
@@ -47,7 +47,7 @@ More conveniently, we can use
 which provides a `contramap` extension method:
 
 ```scala mdoc:silent
-import cats.syntax.contravariant._ // for contramap
+import cats.syntax.contravariant.* // for contramap
 ```
 
 ```scala mdoc
@@ -95,9 +95,9 @@ provided by `cats.syntax.invariant`:
 
 ```scala mdoc:silent
 import cats.Monoid
-import cats.instances.string._ // for Monoid
-import cats.syntax.invariant._ // for imap
-import cats.syntax.semigroup._ // for |+|
+import cats.instances.string.* // for Monoid
+import cats.syntax.invariant.* // for imap
+import cats.syntax.semigroup.* // for |+|
 
 given symbolMonoid: Monoid[Symbol] =
   Monoid[String].imap(Symbol.apply)(_.name)

--- a/src/pages/functors/contravariant-invariant.md
+++ b/src/pages/functors/contravariant-invariant.md
@@ -143,7 +143,7 @@ create your instance from an
 existing instance using `contramap`.
 
 ```scala mdoc:invisible
-implicit def boxPrintable[A](using p: Printable[A]): Printable[Box[A]] =
+given boxPrintable[A](using p: Printable[A]): Printable[Box[A]] =
   p.contramap[Box[A]](_.value)
 ```
 
@@ -220,7 +220,7 @@ given booleanPrintable: Printable[Boolean] with
 final case class Box[A](value: A)
 ```
 ```scala mdoc:silent
-implicit def boxPrintable[A](using p: Printable[A]): Printable[Box[A]] =
+given boxPrintable[A](using p: Printable[A]): Printable[Box[A]] =
   p.contramap[Box[A]](_.value)
 ```
 
@@ -395,7 +395,7 @@ We create this by calling `imap` on a `Codec[A]`,
 which we bring into scope using an implicit parameter:
 
 ```scala mdoc:silent
-implicit def boxCodec[A](using c: Codec[A]): Codec[Box[A]] =
+given boxCodec[A](using c: Codec[A]): Codec[Box[A]] =
   c.imap[Box[A]](Box(_), _.value)
 ```
 </div>

--- a/src/pages/functors/contravariant-invariant.md
+++ b/src/pages/functors/contravariant-invariant.md
@@ -55,7 +55,7 @@ trait Printable[A] {
     ???
 }
 
-def format[A](value: A)(implicit p: Printable[A]): String =
+def format[A](value: A)(using p: Printable[A]): String =
   p.format(value)
 ```
 
@@ -103,7 +103,7 @@ trait Printable[A] { self =>
     }
 }
 
-def format[A](value: A)(implicit p: Printable[A]): String =
+def format[A](value: A)(using p: Printable[A]): String =
   p.format(value)
 ```
 </div>
@@ -113,17 +113,13 @@ let's define some instances of `Printable`
 for `String` and `Boolean`:
 
 ```scala mdoc:silent
-implicit val stringPrintable: Printable[String] =
-  new Printable[String] {
-    def format(value: String): String =
-      s"'${value}'"
-  }
+given stringPrintable: Printable[String] with
+  def format(value: String): String =
+    s"'${value}'"
 
-implicit val booleanPrintable: Printable[Boolean] =
-  new Printable[Boolean] {
-    def format(value: Boolean): String =
-      if(value) "yes" else "no"
-  }
+given booleanPrintable: Printable[Boolean] with
+  def format(value: Boolean): String =
+    if(value) "yes" else "no"
 ```
 
 ```scala mdoc
@@ -147,7 +143,7 @@ create your instance from an
 existing instance using `contramap`.
 
 ```scala mdoc:invisible
-implicit def boxPrintable[A](implicit p: Printable[A]): Printable[Box[A]] =
+implicit def boxPrintable[A](using p: Printable[A]): Printable[Box[A]] =
   p.contramap[Box[A]](_.value)
 ```
 
@@ -210,24 +206,21 @@ trait Printable[A] {
     }
 }
 
-def format[A](value: A)(implicit p: Printable[A]): String =
+def format[A](value: A)(using p: Printable[A]): String =
   p.format(value)
 
-implicit val stringPrintable: Printable[String] =
-  new Printable[String] {
-    def format(value: String): String =
-      s"'${value}'"
-  }
+given stringPrintable: Printable[String] with
+  def format(value: String): String =
+    s"'${value}'"
 
-implicit val booleanPrintable: Printable[Boolean] =
-  new Printable[Boolean] {
-    def format(value: Boolean): String =
-      if(value) "yes" else "no"
-  }
+given booleanPrintable: Printable[Boolean] with
+  def format(value: Boolean): String =
+    if(value) "yes" else "no"
+
 final case class Box[A](value: A)
 ```
 ```scala mdoc:silent
-implicit def boxPrintable[A](implicit p: Printable[A]): Printable[Box[A]] =
+implicit def boxPrintable[A](using p: Printable[A]): Printable[Box[A]] =
   p.contramap[Box[A]](_.value)
 ```
 
@@ -283,10 +276,10 @@ trait Codec[A] {
 ```
 
 ```scala mdoc:silent
-def encode[A](value: A)(implicit c: Codec[A]): String =
+def encode[A](value: A)(using c: Codec[A]): String =
   c.encode(value)
 
-def decode[A](value: String)(implicit c: Codec[A]): A =
+def decode[A](value: String)(using c: Codec[A]): A =
   c.decode(value)
 ```
 
@@ -303,21 +296,19 @@ whose `encode` and `decode` methods both
 simply return the value they are passed:
 
 ```scala mdoc:silent
-implicit val stringCodec: Codec[String] =
-  new Codec[String] {
-    def encode(value: String): String = value
-    def decode(value: String): String = value
-  }
+given stringCodec: Codec[String] with
+  def encode(value: String): String = value
+  def decode(value: String): String = value
 ```
 
 We can construct many useful `Codecs` for other types
 by building off of `stringCodec` using `imap`:
 
 ```scala mdoc:silent
-implicit val intCodec: Codec[Int] =
+given intCodec: Codec[Int] =
   stringCodec.imap(_.toInt, _.toString)
 
-implicit val booleanCodec: Codec[Boolean] =
+given booleanCodec: Codec[Boolean] =
   stringCodec.imap(_.toBoolean, _.toString)
 ```
 
@@ -361,22 +352,20 @@ trait Codec[A] { self =>
 ```
 
 ```scala mdoc:invisible
-implicit val stringCodec: Codec[String] =
-  new Codec[String] {
-    def encode(value: String): String = value
-    def decode(value: String): String = value
-  }
+given stringCodec: Codec[String] with
+  def encode(value: String): String = value
+  def decode(value: String): String = value
 
-implicit val intCodec: Codec[Int] =
+given intCodec: Codec[Int] =
   stringCodec.imap[Int](_.toInt, _.toString)
 
-implicit val booleanCodec: Codec[Boolean] =
+given booleanCodec: Codec[Boolean] =
   stringCodec.imap[Boolean](_.toBoolean, _.toString)
 
-def encode[A](value: A)(implicit c: Codec[A]): String =
+def encode[A](value: A)(using c: Codec[A]): String =
   c.encode(value)
 
-def decode[A](value: String)(implicit c: Codec[A]): A =
+def decode[A](value: String)(using c: Codec[A]): A =
   c.decode(value)
 ```
 </div>
@@ -389,7 +378,7 @@ We can implement this using
 the `imap` method of `stringCodec`:
 
 ```scala mdoc:silent
-implicit val doubleCodec: Codec[Double] =
+given doubleCodec: Codec[Double] =
   stringCodec.imap[Double](_.toDouble, _.toString)
 ```
 </div>
@@ -406,7 +395,7 @@ We create this by calling `imap` on a `Codec[A]`,
 which we bring into scope using an implicit parameter:
 
 ```scala mdoc:silent
-implicit def boxCodec[A](implicit c: Codec[A]): Codec[Box[A]] =
+implicit def boxCodec[A](using c: Codec[A]): Codec[Box[A]] =
   c.imap[Box[A]](Box(_), _.value)
 ```
 </div>

--- a/src/pages/functors/contravariant-invariant.md
+++ b/src/pages/functors/contravariant-invariant.md
@@ -123,7 +123,7 @@ format(true)
 
 Now define an instance of `Printable` for
 the following `Box` case class.
-You'll need to write this as an `implicit def`
+You'll need to write this as a `given` instance
 as described in Section [@sec:type-classes:recursive-implicits]:
 
 ```scala mdoc:silent

--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -102,7 +102,7 @@ seen in `List`, `Option`, and `Either`:
 ```scala mdoc:silent
 import scala.concurrent.{Future, Await}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 val future: Future[String] =
   Future(123).
@@ -210,8 +210,8 @@ We also see this in Figure [@fig:functors:function-type-chart]:
 In other words, "mapping" over a `Function1` is function composition:
 
 ```scala mdoc:silent
-import cats.instances.function._ // for Functor
-import cats.syntax.functor._     // for map
+import cats.instances.function.* // for Functor
+import cats.syntax.functor.*     // for map
 ```
 
 ```scala mdoc:silent

--- a/src/pages/functors/index.md
+++ b/src/pages/functors/index.md
@@ -138,19 +138,19 @@ val future1 = {
   // the next random number in the sequence:
   val x = Future(r.nextInt())
 
-  for {
+  for
     a <- x
     b <- x
-  } yield (a, b)
+  yield (a, b)
 }
 
 val future2 = {
   val r = new Random(0L)
 
-  for {
+  for
     a <- Future(r.nextInt())
     b <- Future(r.nextInt())
-  } yield (a, b)
+  yield (a, b)
 }
 ```
 
@@ -300,9 +300,8 @@ package cats
 
 ```scala mdoc:silent
 
-trait Functor[F[_]] {
+trait Functor[F[_]]:
   def map[A, B](fa: F[A])(f: A => B): F[B]
-}
 ```
 
 If you haven't seen syntax like `F[_]` before,

--- a/src/pages/functors/partial-unification.md
+++ b/src/pages/functors/partial-unification.md
@@ -19,17 +19,15 @@ val func3 = func1.map(func2)
 (the function argument and the result type):
 
 ```scala
-trait Function1[-A, +B] {
+trait Function1[-A, +B]:
   def apply(arg: A): B
-}
 ```
 
 However, `Functor` accepts a type constructor with one parameter:
 
 ```scala
-trait Functor[F[_]] {
+trait Functor[F[_]]:
   def map[A, B](fa: F[A])(func: A => B): F[B]
-}
 ```
 
 The compiler has to fix one of the two parameters

--- a/src/pages/functors/partial-unification.md
+++ b/src/pages/functors/partial-unification.md
@@ -5,8 +5,8 @@ we saw a functor instance for `Function1`.
 
 ```scala mdoc:silent
 import cats.Functor
-import cats.instances.function._ // for Functor
-import cats.syntax.functor._     // for map
+import cats.instances.function.* // for Functor
+import cats.syntax.functor.*     // for map
 
 val func1 = (x: Int)    => x.toDouble
 val func2 = (y: Double) => y * 2
@@ -123,7 +123,7 @@ If we try this for real, however,
 our code won't compile:
 
 ```scala mdoc:silent
-import cats.syntax.contravariant._ // for contramap
+import cats.syntax.contravariant.* // for contramap
 ```
 
 ```scala mdoc:fail

--- a/src/pages/intro/what-is-fp.md
+++ b/src/pages/intro/what-is-fp.md
@@ -30,7 +30,7 @@ In my view functional programming is not about immutability, or keeping to "the 
 ```scala mdoc:silent
 def sum(numbers: List[Int]): Int = {
   var total = 0
-  numbers.foreach(x => total = total + x)
+  numbers foreach { x => total = total + x }
   total
 }
 ```
@@ -50,7 +50,7 @@ val it2 = Iterator(1, 2, 3, 4)
 ```
 
 ```scala mdoc
-it.zip(it2).next()
+(it zip it2).next()
 ```
 
 However if we pass the same generator twice we get a surprising result.
@@ -60,7 +60,7 @@ val it3 = Iterator(1, 2, 3, 4)
 ```
 
 ```scala mdoc
-it3.zip(it3).next()
+(it3 zip it3).next()
 ```
 
 The usual functional programming solution is to avoid mutable state but we can envisage other possibilities. For example, an [effect tracking system][effect-system] would allow us to avoid combining two generators that use the same memory region. These systems are still research projects, however.

--- a/src/pages/links.md
+++ b/src/pages/links.md
@@ -113,6 +113,7 @@
 [link-iterator-pattern]: https://www.cs.ox.ac.uk/jeremy.gibbons/publications/iterator.pdf
 [link-json]: http://json.org/
 [link-kind-projector]: https://github.com/typelevel/kind-projector
+[link-kind-projector-migration]: https://docs.scala-lang.org/scala3/guides/migration/plugin-kind-projector.html
 [link-map-reduce-monoid]: http://arxiv.org/abs/1304.7544
 [link-map-reduce]: http://research.google.com/archive/map-reduce.html
 [link-mdoc]: https://github.com/scalameta/mdoc

--- a/src/pages/links.md
+++ b/src/pages/links.md
@@ -123,7 +123,6 @@
 [link-phil-freeman-tailrecm]: http://functorial.com/stack-safety-for-free/index.pdf
 [link-play-json-format]: https://www.playframework.com/documentation/2.6.x/ScalaJsonCombinators#Format
 [link-sbt]: http://www.scala-sbt.org/
-[link-sbt-catalysts]: https://github.com/typelevel/sbt-catalysts
 [link-scalactic]: http://scalactic.org
 [link-scalaz-contrib]: https://github.com/typelevel/scalaz-contrib
 [link-scodec-codec]: http://scodec.org/guide/Core+Algebra.html#Codec

--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -46,7 +46,7 @@ That is, do monads *compose*?
 We can try to write the code but we soon hit problems:
 
 ```scala mdoc:silent
-import cats.syntax.applicative._ // for pure
+import cats.syntax.applicative.* // for pure
 ```
 
 ```scala
@@ -120,8 +120,8 @@ using the `OptionT` constructor,
 or more conveniently using `pure`:
 
 ```scala mdoc:silent
-import cats.instances.list._     // for Monad
-import cats.syntax.applicative._ // for pure
+import cats.instances.list.*     // for Monad
+import cats.syntax.applicative.* // for pure
 ```
 
 ```scala mdoc
@@ -246,7 +246,7 @@ In other words, we build monad stacks from the inside out:
 
 ```scala mdoc:invisible:reset
 import cats.data.OptionT
-import cats.syntax.applicative._ // for pure
+import cats.syntax.applicative.* // for pure
 ```
 ```scala mdoc:silent
 type ListOption[A] = OptionT[List, A]
@@ -277,7 +277,7 @@ We can use `pure`, `map`, and `flatMap` as usual
 to create and transform instances:
 
 ```scala mdoc:silent
-import cats.instances.either._ // for Monad
+import cats.instances.either.* // for Monad
 ```
 
 ```scala mdoc
@@ -325,10 +325,10 @@ and our `map` and `flatMap` methods
 cut through three layers of abstraction:
 
 ```scala mdoc:silent
-import cats.instances.future._ // for Monad
+import cats.instances.future.* // for Monad
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 ```
 
 ```scala mdoc:silent
@@ -351,7 +351,7 @@ to make it easier to define partially applied type constructors.
 For example:
 
 ```scala mdoc
-import cats.instances.option._ // for Monad
+import cats.instances.option.* // for Monad
 
 123.pure[EitherT[Option, String, *]]
 ```
@@ -452,7 +452,7 @@ and use a fusion `Future` and `Either` everywhere in our code:
 
 ```scala mdoc:invisible:reset-object
 import cats.data.EitherT
-import cats.instances.list._
+import cats.instances.list.*
 import scala.concurrent.Future
 ```
 ```scala mdoc:silent
@@ -589,7 +589,7 @@ val powerLevels = Map(
 )
 ```
 ```scala mdoc:silent
-import cats.instances.future._ // for Monad
+import cats.instances.future.* // for Monad
 import scala.concurrent.ExecutionContext.Implicits.global
 
 type Response[A] = EitherT[Future, String, A]
@@ -621,8 +621,8 @@ We request the power level from each ally
 and use `map` and `flatMap` to combine the results:
 
 ```scala mdoc:invisible:reset-object
-import cats.implicits._
-import cats.data._
+import cats.implicits.*
+import cats.data.*
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -664,8 +664,8 @@ We use the `value` method to unpack the monad stack
 and `Await` and `fold` to unpack the `Future` and `Either`:
 
 ```scala mdoc:invisible:reset
-import cats.implicits._
-import cats.data._
+import cats.implicits.*
+import cats.data.*
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -687,7 +687,7 @@ def getPowerLevel(ally: String): Response[Int] = {
 ```scala mdoc:silent
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 def canSpecialMove(ally1: String, ally2: String): Response[Boolean] =
   for {

--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -297,9 +297,8 @@ However, we can't define this in one line
 because `EitherT` has three type parameters:
 
 ```scala
-case class EitherT[F[_], E, A](stack: F[Either[E, A]]) {
+case class EitherT[F[_], E, A](stack: F[Either[E, A]]):
   // etc...
-}
 ```
 
 The three type parameters are as follows:

--- a/src/pages/monad-transformers/index.md
+++ b/src/pages/monad-transformers/index.md
@@ -482,10 +482,9 @@ type Logged[A] = Writer[List[String], A]
 
 // Methods generally return untransformed stacks:
 def parseNumber(str: String): Logged[Option[Int]] =
-  util.Try(str.toInt).toOption match {
+  util.Try(str.toInt).toOption match
     case Some(num) => Writer(List(s"Read $str"), Some(num))
     case None      => Writer(List(s"Failed on $str"), None)
-  }
 
 // Consumers use monad transformers locally to simplify composition:
 def addAll(a: String, b: String, c: String): Logged[Option[Int]] = {

--- a/src/pages/monads/cats.md
+++ b/src/pages/monads/cats.md
@@ -18,8 +18,8 @@ Here are some examples using `pure` and `flatMap`, and `map` directly:
 
 ```scala mdoc:silent
 import cats.Monad
-import cats.instances.option._ // for Monad
-import cats.instances.list._   // for Monad
+import cats.instances.option.* // for Monad
+import cats.instances.list.*   // for Monad
 ```
 
 ```scala mdoc
@@ -43,7 +43,7 @@ Cats provides instances for all the monads in the standard library
 (`Option`, `List`, `Vector` and so on) via [`cats.instances`][cats.instances]:
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Monad
+import cats.instances.option.* // for Monad
 ```
 
 ```scala mdoc
@@ -51,7 +51,7 @@ Monad[Option].flatMap(Option(1))(a => Option(a*2))
 ```
 
 ```scala mdoc:silent
-import cats.instances.list._ // for Monad
+import cats.instances.list.* // for Monad
 ```
 
 ```scala mdoc
@@ -59,7 +59,7 @@ Monad[List].flatMap(List(1, 2, 3))(a => List(a, a*10))
 ```
 
 ```scala mdoc:silent
-import cats.instances.vector._ // for Monad
+import cats.instances.vector.* // for Monad
 ```
 
 ```scala mdoc
@@ -75,9 +75,9 @@ To work around this, Cats requires us to have an `ExecutionContext` in scope
 when we summon a `Monad` for `Future`:
 
 ```scala mdoc:silent
-import cats.instances.future._ // for Monad
-import scala.concurrent._
-import scala.concurrent.duration._
+import cats.instances.future.* // for Monad
+import scala.concurrent.*
+import scala.concurrent.duration.*
 ```
 
 ```scala mdoc:fail
@@ -129,9 +129,9 @@ We can use `pure` to construct instances of a monad.
 We'll often need to specify the type parameter to disambiguate the particular instance we want.
 
 ```scala mdoc:silent
-import cats.instances.option._   // for Monad
-import cats.instances.list._     // for Monad
-import cats.syntax.applicative._ // for pure
+import cats.instances.option.*   // for Monad
+import cats.instances.list.*     // for Monad
+import cats.syntax.applicative.* // for pure
 ```
 
 ```scala mdoc
@@ -148,14 +148,14 @@ that come wrapped in a monad of the user's choice:
 
 ```scala mdoc:silent
 import cats.Monad
-import cats.syntax.functor._ // for map
-import cats.syntax.flatMap._ // for flatMap
+import cats.syntax.functor.* // for map
+import cats.syntax.flatMap.* // for flatMap
 
 def sumSquare[F[_]: Monad](a: F[Int], b: F[Int]): F[Int] =
   a.flatMap(x => b.map(y => x*x + y*y))
 
-import cats.instances.option._ // for Monad
-import cats.instances.list._   // for Monad
+import cats.instances.option.* // for Monad
+import cats.instances.list.*   // for Monad
 ```
 
 ```scala mdoc
@@ -170,7 +170,7 @@ and inserting the correct implicit conversions to use our `Monad`:
 
 ```scala mdoc:invisible:reset-object
 import cats.Monad
-import cats.implicits._
+import cats.implicits.*
 ```
 ```scala mdoc:silent
 def sumSquare[F[_]: Monad](a: F[Int], b: F[Int]): F[Int] =

--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -173,12 +173,11 @@ given treeMonad: Monad[Tree] with
 
   def flatMap[A, B](tree: Tree[A])
       (func: A => Tree[B]): Tree[B] =
-    tree match {
+    tree match
       case Branch(l, r) =>
         Branch(flatMap(l)(func), flatMap(r)(func))
       case Leaf(value)  =>
         func(value)
-    }
 
   def tailRecM[A, B](a: A)
       (func: A => Tree[Either[A, B]]): Tree[B] =
@@ -224,12 +223,11 @@ given treeMonad: Monad[Tree] with
 
   def flatMap[A, B](tree: Tree[A])
       (func: A => Tree[B]): Tree[B] =
-    tree match {
+    tree match
       case Branch(l, r) =>
         Branch(flatMap(l)(func), flatMap(r)(func))
       case Leaf(value)  =>
         func(value)
-    }
 
   def tailRecM[A, B](arg: A)(
     func: A => Tree[Either[A, B]]
@@ -238,7 +236,7 @@ given treeMonad: Monad[Tree] with
     def loop(
           open: List[Tree[Either[A, B]]],
           closed: List[Option[Tree[B]]]): List[Tree[B]] =
-      open match {
+      open match
         case Branch(l, r) :: next =>
           loop(l :: r :: next, None :: closed)
 
@@ -255,7 +253,7 @@ given treeMonad: Monad[Tree] with
               branch(left, right) :: tail
             }
           }
-      }
+      end match
 
     loop(List(func(arg)), Nil).head
   }

--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -47,7 +47,7 @@ and many monads have some notion of stopping.
 We can write this method in terms of `flatMap`.
 
 ```scala mdoc:silent
-import cats.syntax.flatMap._ // For flatMap
+import cats.syntax.flatMap.* // For flatMap
 
 def retry[F[_]: Monad, A](start: A)(f: A => F[A]): F[A] =
   f(start).flatMap{ a =>
@@ -59,7 +59,7 @@ Unfortunately it is not stack-safe.
 It works for small input.
 
 ```scala mdoc
-import cats.instances.option._
+import cats.instances.option.*
 
 retry(100)(a => if(a == 0) None else Some(a - 1))
 ```
@@ -75,7 +75,7 @@ We can instead rewrite this method
 using `tailRecM`.
 
 ```scala mdoc:silent
-import cats.syntax.functor._ // for map
+import cats.syntax.functor.* // for map
 
 def retryTailRecM[F[_]: Monad, A](start: A)(f: A => F[A]): F[A] =
   Monad[F].tailRecM(start){ a =>
@@ -104,7 +104,7 @@ in terms of `iterateWhileM`
 and we don't have to explicitly call `tailRecM`.
 
 ```scala mdoc:silent
-import cats.syntax.monad._ // for iterateWhileM
+import cats.syntax.monad.* // for iterateWhileM
 
 def retryM[F[_]: Monad, A](start: A)(f: A => F[A]): F[A] =
   start.iterateWhileM(f)(a => true)
@@ -265,8 +265,8 @@ Regardless of which version of `tailRecM` we define,
 we can use our `Monad` to `flatMap` and `map` on `Trees`:
 
 ```scala mdoc:silent
-import cats.syntax.functor._ // for map
-import cats.syntax.flatMap._ // for flatMap
+import cats.syntax.functor.* // for map
+import cats.syntax.flatMap.* // for flatMap
 ```
 
 ```scala mdoc

--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -167,7 +167,7 @@ the non-tail-recursive solution falls out:
 ```scala mdoc:silent
 import cats.Monad
 
-implicit val treeMonad = new Monad[Tree] {
+implicit val treeMonad: Monad[Tree] = new Monad[Tree] {
   def pure[A](value: A): Tree[A] =
     Leaf(value)
 
@@ -180,14 +180,14 @@ implicit val treeMonad = new Monad[Tree] {
         func(value)
     }
 
- def tailRecM[A, B](a: A)
-     (func: A => Tree[Either[A, B]]): Tree[B] =
-   flatMap(func(a)) {
-     case Left(value) =>
-       tailRecM(value)(func)
-     case Right(value) =>
-       Leaf(value)
-   }
+  def tailRecM[A, B](a: A)
+      (func: A => Tree[Either[A, B]]): Tree[B] =
+    flatMap(func(a)) {
+      case Left(value) =>
+        tailRecM(value)(func)
+      case Right(value) =>
+        Leaf(value)
+    }
 }
 ```
 
@@ -219,7 +219,7 @@ def leaf[A](value: A): Tree[A] =
 import cats.Monad
 import scala.annotation.tailrec
 
-implicit val treeMonad = new Monad[Tree] {
+implicit val treeMonad: Monad[Tree] = new Monad[Tree] {
   def pure[A](value: A): Tree[A] =
     Leaf(value)
 
@@ -232,8 +232,9 @@ implicit val treeMonad = new Monad[Tree] {
         func(value)
     }
 
-  def tailRecM[A, B](arg: A)
-      (func: A => Tree[Either[A, B]]): Tree[B] = {
+  def tailRecM[A, B](arg: A)(
+    func: A => Tree[Either[A, B]]
+  ): Tree[B] = {
     @tailrec
     def loop(
           open: List[Tree[Either[A, B]]],

--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -167,7 +167,7 @@ the non-tail-recursive solution falls out:
 ```scala mdoc:silent
 import cats.Monad
 
-implicit val treeMonad: Monad[Tree] = new Monad[Tree] {
+given treeMonad: Monad[Tree] with
   def pure[A](value: A): Tree[A] =
     Leaf(value)
 
@@ -188,7 +188,6 @@ implicit val treeMonad: Monad[Tree] = new Monad[Tree] {
       case Right(value) =>
         Leaf(value)
     }
-}
 ```
 
 The solution above is perfectly fine for this exercise.
@@ -219,7 +218,7 @@ def leaf[A](value: A): Tree[A] =
 import cats.Monad
 import scala.annotation.tailrec
 
-implicit val treeMonad: Monad[Tree] = new Monad[Tree] {
+given treeMonad: Monad[Tree] with
   def pure[A](value: A): Tree[A] =
     Leaf(value)
 
@@ -260,7 +259,6 @@ implicit val treeMonad: Monad[Tree] = new Monad[Tree] {
 
     loop(List(func(arg)), Nil).head
   }
-}
 ```
 
 Regardless of which version of `tailRecM` we define,

--- a/src/pages/monads/custom-instances.md
+++ b/src/pages/monads/custom-instances.md
@@ -127,12 +127,12 @@ Let's write a `Monad` for our `Tree` data type from last chapter.
 Here's the type again:
 
 ```scala mdoc:silent
-sealed trait Tree[+A]
+enum Tree[+A] {
+  case Branch[A](left: Tree[A], right: Tree[A]) extends Tree[A]
+  case Leaf[A](value: A) extends Tree[A]
+}
 
-final case class Branch[A](left: Tree[A], right: Tree[A])
-  extends Tree[A]
-
-final case class Leaf[A](value: A) extends Tree[A]
+import Tree.{Branch, Leaf}
 
 def branch[A](left: Tree[A], right: Tree[A]): Tree[A] =
   Branch(left, right)

--- a/src/pages/monads/either.md
+++ b/src/pages/monads/either.md
@@ -261,7 +261,7 @@ on any pattern matching we do:
 ```scala mdoc:silent
 // Choose error-handling behaviour based on type:
 def handleError(error: LoginError): Unit =
-  error match {
+  error match
     case UserNotFound(u) =>
       println(s"User not found: $u")
 
@@ -270,7 +270,6 @@ def handleError(error: LoginError): Unit =
 
     case UnexpectedError =>
       println(s"Unexpected error")
-  }
 ```
 
 ```scala mdoc

--- a/src/pages/monads/either.md
+++ b/src/pages/monads/either.md
@@ -49,7 +49,7 @@ In Scala 2.12+ we can either omit this import
 or leave it in place without breaking anything:
 
 ```scala mdoc:silent
-import cats.syntax.either._ // for map and flatMap
+import cats.syntax.either.* // for map and flatMap
 
 for {
   a <- either1
@@ -64,7 +64,7 @@ we can also import the `asLeft` and `asRight` extension methods
 from [`cats.syntax.either`][cats.syntax.either]:
 
 ```scala mdoc:silent
-import cats.syntax.either._ // for asRight
+import cats.syntax.either.* // for asRight
 ```
 
 ```scala mdoc
@@ -154,7 +154,7 @@ can use `orElse` and `getOrElse` to extract
 values from the right side or return a default:
 
 ```scala mdoc:silent
-import cats.syntax.either._
+import cats.syntax.either.*
 ```
 
 ```scala mdoc
@@ -241,7 +241,7 @@ object wrapper {
     case PasswordIncorrect(username: String)
     case UnexpectedError
   }
-}; import wrapper._
+}; import wrapper.*
 
 import LoginError.*
 ```

--- a/src/pages/monads/either.md
+++ b/src/pages/monads/either.md
@@ -235,13 +235,13 @@ Another approach is to define an algebraic data type
 to represent errors that may occur in our program:
 
 ```scala mdoc:silent
-object wrapper {
-  enum LoginError {
+object wrapper:
+  enum LoginError:
     case UserNotFound(username: String)
     case PasswordIncorrect(username: String)
     case UnexpectedError
-  }
-}; import wrapper.*
+
+import wrapper.*
 
 import LoginError.*
 ```

--- a/src/pages/monads/either.md
+++ b/src/pages/monads/either.md
@@ -236,16 +236,14 @@ to represent errors that may occur in our program:
 
 ```scala mdoc:silent
 object wrapper {
-  sealed trait LoginError extends Product with Serializable
-
-  final case class UserNotFound(username: String)
-    extends LoginError
-
-  final case class PasswordIncorrect(username: String)
-    extends LoginError
-
-  case object UnexpectedError extends LoginError
+  enum LoginError {
+    case UserNotFound(username: String)
+    case PasswordIncorrect(username: String)
+    case UnexpectedError
+  }
 }; import wrapper._
+
+import LoginError.*
 ```
 
 ```scala mdoc:silent

--- a/src/pages/monads/eval.md
+++ b/src/pages/monads/eval.md
@@ -310,12 +310,11 @@ Make it so using `Eval`:
 
 ```scala mdoc:silent
 def foldRight[A, B](as: List[A], acc: B)(fn: (A, B) => B): B =
-  as match {
+  as match
     case head :: tail =>
       fn(head, foldRight(tail, acc)(fn))
     case Nil =>
       acc
-  }
 ```
 
 <div class="solution">
@@ -330,12 +329,11 @@ import cats.Eval
 
 def foldRightEval[A, B](as: List[A], acc: Eval[B])
     (fn: (A, Eval[B]) => Eval[B]): Eval[B] =
-  as match {
+  as match
     case head :: tail =>
       Eval.defer(fn(head, foldRightEval(tail, acc)(fn)))
     case Nil =>
       acc
-  }
 ```
 
 We can redefine `foldRight` simply in terms of `foldRightEval`

--- a/src/pages/monads/id.md
+++ b/src/pages/monads/id.md
@@ -5,8 +5,8 @@ by writing a method that abstracted over different monads:
 
 ```scala mdoc:silent
 import cats.Monad
-import cats.syntax.functor._ // for map
-import cats.syntax.flatMap._ // for flatMap
+import cats.syntax.functor.* // for map
+import cats.syntax.flatMap.* // for flatMap
 
 def sumSquare[F[_]: Monad](a: F[Int], b: F[Int]): F[Int] =
   for {
@@ -69,8 +69,8 @@ val b = Monad[Id].flatMap(a)(_ + 1)
 ```
 
 ```scala mdoc:silent
-import cats.syntax.functor._ // for map
-import cats.syntax.flatMap._ // for flatMap
+import cats.syntax.functor.* // for map
+import cats.syntax.flatMap.* // for flatMap
 ```
 
 ```scala mdoc
@@ -116,8 +116,8 @@ All we have to do is return the initial value:
 
 ```scala mdoc:invisible:reset-object
 import cats.{Id,Monad}
-import cats.syntax.functor._ 
-import cats.syntax.flatMap._
+import cats.syntax.functor.* 
+import cats.syntax.flatMap.*
 def sumSquare[F[_]: Monad](a: F[Int], b: F[Int]): F[Int] =
   for {
     x <- a

--- a/src/pages/monads/index.md
+++ b/src/pages/monads/index.md
@@ -257,11 +257,10 @@ Here is a simplified version of the `Monad` type class in Cats:
 
 ```scala mdoc:silent
 
-trait Monad[F[_]] {
+trait Monad[F[_]]:
   def pure[A](value: A): F[A]
 
   def flatMap[A, B](value: F[A])(func: A => F[B]): F[B]
-}
 ```
 
 <div class="callout callout-warning">
@@ -302,14 +301,13 @@ using the existing methods, `flatMap` and `pure`:
 
 ```scala mdoc:silent:reset-object
 
-trait Monad[F[_]] {
+trait Monad[F[_]]:
   def pure[A](a: A): F[A]
 
   def flatMap[A, B](value: F[A])(func: A => F[B]): F[B]
 
   def map[A, B](value: F[A])(func: A => B): F[B] =
     ???
-}
 ```
 
 Try defining `map` yourself now.
@@ -322,14 +320,13 @@ Given the tools available there's only one thing we can do:
 call `flatMap`:
 
 ```scala
-trait Monad[F[_]] {
+trait Monad[F[_]]:
   def pure[A](value: A): F[A]
 
   def flatMap[A, B](value: F[A])(func: A => F[B]): F[B]
 
   def map[A, B](value: F[A])(func: A => B): F[B] =
     flatMap(value)(a => ???)
-}
 ```
 
 We need a function of type `A => F[B]` as the second parameter.
@@ -341,13 +338,12 @@ Combining these gives us our result:
 ```scala mdoc:invisible:reset-object
 ```
 ```scala mdoc
-trait Monad[F[_]] {
+trait Monad[F[_]]:
   def pure[A](value: A): F[A]
 
   def flatMap[A, B](value: F[A])(func: A => F[B]): F[B]
 
   def map[A, B](value: F[A])(func: A => B): F[B] =
     flatMap(value)(a => pure(func(a)))
-}
 ```
 </div>

--- a/src/pages/monads/monad-error.md
+++ b/src/pages/monads/monad-error.md
@@ -55,7 +55,7 @@ instantiate the type class for `Either`:
 
 ```scala mdoc:silent
 import cats.MonadError
-import cats.instances.either._ // for MonadError
+import cats.instances.either.* // for MonadError
 
 type ErrorOr[A] = Either[String, A]
 
@@ -126,14 +126,14 @@ and `ensure` via [`cats.syntax.monadError`][cats.syntax.monadError]:
 
 ```scala mdoc:invisible:reset
 import cats.MonadError
-import cats.instances.either._ // for MonadError
+import cats.instances.either.* // for MonadError
 
 type ErrorOr[A] = Either[String, A]
 ```
 ```scala mdoc:silent
-import cats.syntax.applicative._      // for pure
-import cats.syntax.applicativeError._ // for raiseError etc
-import cats.syntax.monadError._       // for ensure
+import cats.syntax.applicative.*      // for pure
+import cats.syntax.applicativeError.* // for raiseError etc
+import cats.syntax.monadError.*       // for ensure
 ```
 
 ```scala mdoc
@@ -165,7 +165,7 @@ always represent errors as `Throwables`:
 
 ```scala mdoc:silent
 import scala.util.Try
-import cats.instances.try_._ // for MonadError
+import cats.instances.try_.* // for MonadError
 
 val exn: Throwable =
   new RuntimeException("It's all gone wrong")
@@ -206,7 +206,7 @@ We can solve this using `pure` and `raiseError`. Note the use of type parameters
 
 ```scala mdoc:invisible:reset-object
 import cats.MonadError
-import cats.implicits._
+import cats.implicits.*
 ```
 ```scala mdoc:silent
 def validateAdult[F[_]](age: Int)(using me: MonadError[F, Throwable]): F[Int] =

--- a/src/pages/monads/monad-error.md
+++ b/src/pages/monads/monad-error.md
@@ -28,7 +28,7 @@ of the definition of `MonadError`:
 ```scala
 package cats
 
-trait MonadError[F[_], E] extends Monad[F] {
+trait MonadError[F[_], E] extends Monad[F]:
   // Lift an error into the `F` context:
   def raiseError[A](e: E): F[A]
 
@@ -41,7 +41,6 @@ trait MonadError[F[_], E] extends Monad[F] {
   // Test an instance of `F`,
   // failing if the predicate is not satisfied:
   def ensure[A](fa: F[A])(e: E)(f: A => Boolean): F[A]
-}
 ```
 
 `MonadError` is defined in terms of two type parameters:

--- a/src/pages/monads/monad-error.md
+++ b/src/pages/monads/monad-error.md
@@ -180,14 +180,14 @@ exn.raiseError[Try, Int]
 Implement a method `validateAdult` with the following signature
 
 ```scala
-def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] =
+def validateAdult[F[_]](age: Int)(using me: MonadError[F, Throwable]): F[Int] =
   ???
 ```
 
 When passed an `age` greater than or equal to 18 it should return that value as a success. Otherwise it should return a error represented as an `IllegalArgumentException`.
 
 ```scala mdoc:invisible
-def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] =
+def validateAdult[F[_]](age: Int)(using me: MonadError[F, Throwable]): F[Int] =
   if(age >= 18) age.pure[F]
   else new IllegalArgumentException("Age must be greater than or equal to 18").raiseError[F, Int]
 ```
@@ -209,7 +209,7 @@ import cats.MonadError
 import cats.implicits._
 ```
 ```scala mdoc:silent
-def validateAdult[F[_]](age: Int)(implicit me: MonadError[F, Throwable]): F[Int] =
+def validateAdult[F[_]](age: Int)(using me: MonadError[F, Throwable]): F[Int] =
   if(age >= 18) age.pure[F]
   else new IllegalArgumentException("Age must be greater than or equal to 18").raiseError[F, Int]
 ```

--- a/src/pages/monads/reader.md
+++ b/src/pages/monads/reader.md
@@ -184,7 +184,7 @@ def checkPassword(
   Reader(db => db.passwords.get(username).contains(password))
 ```
 ```scala mdoc:silent
-import cats.syntax.applicative._ // for pure
+import cats.syntax.applicative.* // for pure
 
 def checkLogin(
       userId: Int,

--- a/src/pages/monads/state.md
+++ b/src/pages/monads/state.md
@@ -121,7 +121,7 @@ that only represent transformations on the state:
 
 ```scala mdoc:silent:reset-object
 import cats.data.State
-import State._
+import State.*
 ```
 
 ```scala mdoc
@@ -351,7 +351,7 @@ def evalOne(sym: String): CalcState[Int] =
   }
 ```
 ```scala mdoc:silent
-import cats.syntax.applicative._ // for pure
+import cats.syntax.applicative.* // for pure
 
 def evalAll(input: List[String]): CalcState[Int] =
   input.foldLeft(0.pure[CalcState]) { (a, b) =>

--- a/src/pages/monads/state.md
+++ b/src/pages/monads/state.md
@@ -234,13 +234,12 @@ type CalcState[A] = State[List[Int], A]
 ```
 ```scala
 def evalOne(sym: String): CalcState[Int] =
-  sym match {
+  sym match
     case "+" => operator(_ + _)
     case "-" => operator(_ - _)
     case "*" => operator(_ * _)
     case "/" => operator(_ / _)
     case num => operand(num.toInt)
-  }
 ```
 
 Let's look at `operand` first.
@@ -275,13 +274,12 @@ def operator(func: (Int, Int) => Int): CalcState[Int] =
 
 ```scala mdoc:invisible
 def evalOne(sym: String): CalcState[Int] =
-  sym match {
+  sym match
     case "+" => operator(_ + _)
     case "-" => operator(_ - _)
     case "*" => operator(_ * _)
     case "/" => operator(_ / _)
     case num => operand(num.toInt)
-  }
 ```
 </div>
 
@@ -342,13 +340,12 @@ def operator(func: (Int, Int) => Int): CalcState[Int] =
       sys.error("Fail!")
   }
 def evalOne(sym: String): CalcState[Int] =
-  sym match {
+  sym match
     case "+" => operator(_ + _)
     case "-" => operator(_ - _)
     case "*" => operator(_ * _)
     case "/" => operator(_ / _)
     case num => operand(num.toInt)
-  }
 ```
 ```scala mdoc:silent
 import cats.syntax.applicative.* // for pure

--- a/src/pages/monads/writer.md
+++ b/src/pages/monads/writer.md
@@ -34,7 +34,7 @@ We can create a `Writer` from values of each type as follows:
 
 ```scala mdoc:silent
 import cats.data.Writer
-import cats.instances.vector._ // for Monoid
+import cats.instances.vector.* // for Monoid
 ```
 
 ```scala mdoc
@@ -67,8 +67,8 @@ To do this we must have a `Monoid[W]` in scope
 so Cats knows how to produce an empty log:
 
 ```scala mdoc:silent
-import cats.instances.vector._   // for Monoid
-import cats.syntax.applicative._ // for pure
+import cats.instances.vector.*   // for Monoid
+import cats.syntax.applicative.* // for pure
 
 type Logged[A] = Writer[Vector[String], A]
 ```
@@ -82,7 +82,7 @@ we can create a `Writer[Unit]` using the `tell` syntax
 from [`cats.syntax.writer`][cats.syntax.writer]:
 
 ```scala mdoc:silent
-import cats.syntax.writer._ // for tell
+import cats.syntax.writer.* // for tell
 ```
 
 ```scala mdoc
@@ -95,7 +95,7 @@ or we can use the `writer` syntax
 from [`cats.syntax.writer`][cats.syntax.writer]:
 
 ```scala mdoc:silent
-import cats.syntax.writer._ // for writer
+import cats.syntax.writer.* // for writer
 ```
 
 ```scala mdoc
@@ -214,9 +214,9 @@ This makes it difficult to see
 which messages come from which computation:
 
 ```scala
-import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.ExecutionContext.Implicits.*
+import scala.concurrent.duration.*
 
 Await.result(Future.sequence(Vector(
   Future(factorial(5)),
@@ -255,8 +255,8 @@ so we can use it with `pure` syntax:
 
 ```scala mdoc:silent:reset-object
 import cats.data.Writer
-import cats.instances.vector._
-import cats.syntax.applicative._ // for pure
+import cats.instances.vector.*
+import cats.syntax.applicative.* // for pure
 
 type Logged[A] = Writer[Vector[String], A]
 ```
@@ -268,7 +268,7 @@ type Logged[A] = Writer[Vector[String], A]
 We'll import the `tell` syntax as well:
 
 ```scala mdoc:silent
-import cats.syntax.writer._ // for tell
+import cats.syntax.writer.* // for tell
 ```
 
 ```scala mdoc
@@ -280,7 +280,7 @@ the `Semigroup` instance for `Vector`.
 We need this to `map` and `flatMap` over `Logged`:
 
 ```scala mdoc:silent
-import cats.instances.vector._ // for Monoid
+import cats.instances.vector.* // for Monoid
 ```
 
 ```scala mdoc

--- a/src/pages/monoids/cats.md
+++ b/src/pages/monoids/cats.md
@@ -187,7 +187,7 @@ We can write this as a generic method that accepts an implicit `Monoid` as a par
 import cats.Monoid
 import cats.syntax.semigroup._ // for |+|
 
-def add[A](items: List[A])(implicit monoid: Monoid[A]): A =
+def add[A](items: List[A])(using monoid: Monoid[A]): A =
   items.foldLeft(monoid.empty)(_ |+| _)
 ```
 
@@ -247,7 +247,7 @@ Make it so!
 Easy---we simply define a monoid instance for `Order`!
 
 ```scala mdoc:silent
-implicit val monoid: Monoid[Order] = new Monoid[Order] {
+given monoid: Monoid[Order] with
   def combine(o1: Order, o2: Order) =
     Order(
       o1.totalCost + o2.totalCost,
@@ -255,6 +255,5 @@ implicit val monoid: Monoid[Order] = new Monoid[Order] {
     )
 
   def empty = Order(0, 0)
-}
 ```
 </div>

--- a/src/pages/monoids/cats.md
+++ b/src/pages/monoids/cats.md
@@ -45,7 +45,7 @@ are defined directly in the [`cats`][cats.package] package.
 the companion object has an `apply` method
 that returns the type class instance for a particular type.
 For example, if we want the monoid instance for `String`,
-and we have the correct implicits in scope,
+and we have the correct given instances in scope,
 we can write the following:
 
 ```scala mdoc:silent

--- a/src/pages/monoids/cats.md
+++ b/src/pages/monoids/cats.md
@@ -50,7 +50,7 @@ we can write the following:
 
 ```scala mdoc:silent
 import cats.Monoid
-import cats.instances.string._ // for Monoid
+import cats.instances.string.* // for Monoid
 ```
 
 ```scala mdoc
@@ -85,7 +85,7 @@ we import from [`cats.instances.int`][cats.instances.int]:
 
 ```scala mdoc:silent
 import cats.Monoid
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 ```
 
 ```scala mdoc
@@ -98,8 +98,8 @@ and [`cats.instances.option`][cats.instances.option]:
 
 ```scala mdoc:silent
 import cats.Monoid
-import cats.instances.int._    // for Monoid
-import cats.instances.option._ // for Monoid
+import cats.instances.int.*    // for Monoid
+import cats.instances.option.* // for Monoid
 ```
 
 ```scala mdoc
@@ -116,8 +116,8 @@ As always, unless we have a good reason to import individual instances,
 we can just import everything.
 
 ```scala
-import cats._
-import cats.implicits._
+import cats.*
+import cats.implicits.*
 ```
 
 ### Monoid Syntax {#sec:monoid-syntax}
@@ -128,8 +128,8 @@ Because `combine` technically comes from `Semigroup`,
 we access the syntax by importing from [`cats.syntax.semigroup`][cats.syntax.semigroup]:
 
 ```scala mdoc:silent
-import cats.instances.string._ // for Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.instances.string.* // for Monoid
+import cats.syntax.semigroup.* // for |+|
 ```
 
 ```scala mdoc
@@ -137,7 +137,7 @@ val stringResult = "Hi " |+| "there" |+| Monoid[String].empty
 ```
 
 ```scala mdoc:silent
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 ```
 
 ```scala mdoc
@@ -163,8 +163,8 @@ although there's not a compelling use case for this yet:
 
 ```scala mdoc:silent:reset-object
 import cats.Monoid
-import cats.instances.int._    // for Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.instances.int.*    // for Monoid
+import cats.syntax.semigroup.* // for |+|
 
 def add(items: List[Int]): Int =
   items.foldLeft(Monoid[Int].empty)(_ |+| _)
@@ -185,7 +185,7 @@ We can write this as a generic method that accepts an implicit `Monoid` as a par
 
 ```scala mdoc:silent:reset-object
 import cats.Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.syntax.semigroup.* // for |+|
 
 def add[A](items: List[A])(using monoid: Monoid[A]): A =
   items.foldLeft(monoid.empty)(_ |+| _)
@@ -195,8 +195,8 @@ We can optionally use Scala's *context bound* syntax to write the same code in a
 
 ```scala mdoc:invisible:reset-object
 import cats.Monoid
-import cats.instances.int._    // for Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.instances.int.*    // for Monoid
+import cats.syntax.semigroup.* // for |+|
 ```
 ```scala mdoc:silent
 def add[A: Monoid](items: List[A]): A =
@@ -206,7 +206,7 @@ def add[A: Monoid](items: List[A]): A =
 We can use this code to add values of type `Int` and `Option[Int]` as requested:
 
 ```scala mdoc:silent
-import cats.instances.int._ // for Monoid
+import cats.instances.int.* // for Monoid
 ```
 
 ```scala mdoc
@@ -214,7 +214,7 @@ add(List(1, 2, 3))
 ```
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Monoid
+import cats.instances.option.* // for Monoid
 ```
 
 ```scala mdoc

--- a/src/pages/monoids/index.md
+++ b/src/pages/monoids/index.md
@@ -114,13 +114,13 @@ For all values `x`, `y`, and `z`, in `A`,
 
 ```scala mdoc:silent
 def associativeLaw[A](x: A, y: A, z: A)
-      (implicit m: Monoid[A]): Boolean = {
+      (using m: Monoid[A]): Boolean = {
   m.combine(x, m.combine(y, z)) ==
     m.combine(m.combine(x, y), z)
 }
 
 def identityLaw[A](x: A)
-      (implicit m: Monoid[A]): Boolean = {
+      (using m: Monoid[A]): Boolean = {
   (m.combine(x, m.empty) == x) &&
     (m.combine(m.empty, x) == x)
 }
@@ -194,7 +194,7 @@ trait Monoid[A] extends Semigroup[A] {
 }
 
 object Monoid {
-  def apply[A](implicit monoid: Monoid[A]) =
+  def apply[A](using monoid: Monoid[A]) =
     monoid
 }
 ```
@@ -204,46 +204,38 @@ There are four monoids for `Boolean`!
 First, we have *and* with operator `&&` and identity `true`:
 
 ```scala mdoc:silent
-implicit val booleanAndMonoid: Monoid[Boolean] =
-  new Monoid[Boolean] {
-    def combine(a: Boolean, b: Boolean) = a && b
-    def empty = true
-  }
+given booleanAndMonoid: Monoid[Boolean] with
+  def combine(a: Boolean, b: Boolean) = a && b
+  def empty = true
 ```
 
 Second, we have *or* with operator `||` and identity `false`:
 
 ```scala mdoc:silent
-implicit val booleanOrMonoid: Monoid[Boolean] =
-  new Monoid[Boolean] {
-    def combine(a: Boolean, b: Boolean) = a || b
-    def empty = false
-  }
+given booleanOrMonoid: Monoid[Boolean] with
+  def combine(a: Boolean, b: Boolean) = a || b
+  def empty = false
 ```
 
 Third, we have *exclusive or* with identity `false`:
 
 ```scala mdoc:silent
-implicit val booleanEitherMonoid: Monoid[Boolean] =
-  new Monoid[Boolean] {
-    def combine(a: Boolean, b: Boolean) =
-      (a && !b) || (!a && b)
+given booleanEitherMonoid: Monoid[Boolean] with
+  def combine(a: Boolean, b: Boolean) =
+    (a && !b) || (!a && b)
 
-    def empty = false
-  }
+  def empty = false
 ```
 
 Finally, we have *exclusive nor* (the negation of exclusive or)
 with identity `true`:
 
 ```scala mdoc:silent
-implicit val booleanXnorMonoid: Monoid[Boolean] =
-  new Monoid[Boolean] {
-    def combine(a: Boolean, b: Boolean) =
-      (!a || b) && (a || !b)
+given booleanXnorMonoid: Monoid[Boolean] with
+  def combine(a: Boolean, b: Boolean) =
+    (!a || b) && (a || !b)
 
-    def empty = true
-  }
+  def empty = true
 ```
 
 Showing that the identity law holds in each case is straightforward.

--- a/src/pages/monoids/index.md
+++ b/src/pages/monoids/index.md
@@ -100,10 +100,9 @@ This definition translates nicely into Scala code.
 Here is a simplified version of the definition from Cats:
 
 ```scala mdoc:silent
-trait Monoid[A] {
+trait Monoid[A]:
   def combine(x: A, y: A): A
   def empty: A
-}
 ```
 
 In addition to providing the `combine` and `empty` operations,
@@ -161,13 +160,11 @@ A more accurate (though still simplified)
 definition of Cats' [`Monoid`][cats.Monoid] is:
 
 ```scala mdoc:silent:reset-object
-trait Semigroup[A] {
+trait Semigroup[A]:
   def combine(x: A, y: A): A
-}
 
-trait Monoid[A] extends Semigroup[A] {
+trait Monoid[A] extends Semigroup[A]:
   def empty: A
-}
 ```
 
 We'll see this kind of inheritance often when discussing type classes.
@@ -185,18 +182,15 @@ and convince yourself that the monoid laws hold.
 Use the following definitions as a starting point:
 
 ```scala mdoc:reset:silent
-trait Semigroup[A] {
+trait Semigroup[A]:
   def combine(x: A, y: A): A
-}
 
-trait Monoid[A] extends Semigroup[A] {
+trait Monoid[A] extends Semigroup[A]:
   def empty: A
-}
 
-object Monoid {
+object Monoid:
   def apply[A](using monoid: Monoid[A]) =
     monoid
-}
 ```
 
 <div class="solution">

--- a/src/pages/monoids/index.md
+++ b/src/pages/monoids/index.md
@@ -251,11 +251,9 @@ What monoids and semigroups are there for sets?
 *Set union* forms a monoid along with the empty set:
 
 ```scala mdoc:silent
-implicit def setUnionMonoid[A]: Monoid[Set[A]] =
-  new Monoid[Set[A]] {
-    def combine(a: Set[A], b: Set[A]) = a union b
-    def empty = Set.empty[A]
-  }
+given setUnionMonoid[A]: Monoid[Set[A]] with
+  def combine(a: Set[A], b: Set[A]) = a union b
+  def empty = Set.empty[A]
 ```
 
 We need to define `setUnionMonoid` as a method
@@ -277,11 +275,9 @@ Set intersection forms a semigroup,
 but doesn't form a monoid because it has no identity element:
 
 ```scala mdoc:silent
-implicit def setIntersectionSemigroup[A]: Semigroup[Set[A]] =
-  new Semigroup[Set[A]] {
-    def combine(a: Set[A], b: Set[A]) =
-      a intersect b
-  }
+given setIntersectionSemigroup[A]: Semigroup[Set[A]] with
+  def combine(a: Set[A], b: Set[A]) =
+    a intersect b
 ```
 
 Set complement and set difference are not associative,
@@ -293,11 +289,9 @@ does also form a monoid with the empty set:
 import cats.Monoid
 ```
 ```scala mdoc:silent
-implicit def symDiffMonoid[A]: Monoid[Set[A]] =
-  new Monoid[Set[A]] {
-    def combine(a: Set[A], b: Set[A]): Set[A] =
-      (a diff b) union (b diff a)
-    def empty: Set[A] = Set.empty
-  }
+given symDiffMonoid[A]: Monoid[Set[A]] with
+  def combine(a: Set[A], b: Set[A]): Set[A] =
+    (a diff b) union (b diff a)
+  def empty: Set[A] = Set.empty
 ```
 </div>

--- a/src/pages/monoids/summary.md
+++ b/src/pages/monoids/summary.md
@@ -12,8 +12,8 @@ and the semigroup syntax to give us the `|+|` operator:
 
 ```scala mdoc:silent
 import cats.Monoid
-import cats.instances.string._ // for Monoid
-import cats.syntax.semigroup._ // for |+|
+import cats.instances.string.* // for Monoid
+import cats.syntax.semigroup.* // for |+|
 ```
 
 ```scala mdoc
@@ -24,8 +24,8 @@ With the correct instances in scope,
 we can set about adding anything we want:
 
 ```scala mdoc:silent
-import cats.instances.int._    // for Monoid
-import cats.instances.option._ // for Monoid
+import cats.instances.int.*    // for Monoid
+import cats.instances.option.* // for Monoid
 ```
 
 ```scala mdoc
@@ -33,7 +33,7 @@ Option(1) |+| Option(2)
 ```
 
 ```scala mdoc:silent
-import cats.instances.map._ // for Monoid
+import cats.instances.map.* // for Monoid
 
 val map1 = Map("a" -> 1, "b" -> 2)
 val map2 = Map("b" -> 3, "d" -> 4)
@@ -44,7 +44,7 @@ map1 |+| map2
 ```
 
 ```scala mdoc:silent
-import cats.instances.tuple._  // for Monoid
+import cats.instances.tuple.*  // for Monoid
 
 
 val tuple1 = ("hello", 123)

--- a/src/pages/monoids/summary.md
+++ b/src/pages/monoids/summary.md
@@ -60,7 +60,7 @@ for which we have an instance of `Monoid`:
 
 ```scala mdoc:silent
 def addAll[A](values: List[A])
-      (implicit monoid: Monoid[A]): A =
+      (using monoid: Monoid[A]): A =
   values.foldRight(monoid.empty)(_ |+| _)
 ```
 

--- a/src/pages/preface/conventions.md
+++ b/src/pages/preface/conventions.md
@@ -25,9 +25,8 @@ Source code blocks are written as follows.
 Syntax is highlighted appropriately where applicable:
 
 ```scala mdoc:silent
-object MyApp extends App {
+object MyApp extends App:
   println("Hello world!") // Print a fine message to the user!
-}
 ```
 
 Most code passes through [mdoc][link-mdoc] to ensure it compiles.

--- a/src/pages/preface/versions.md
+++ b/src/pages/preface/versions.md
@@ -33,19 +33,3 @@ with Cats as a dependency.
 See the generated `README.md` for
 instructions on how to run the sample code
 and/or start an interactive Scala console.
-
-The `cats-seed` template is very minimal.
-If you'd prefer a more batteries-included starting point,
-check out Typelevel's `sbt-catalysts` template:
-
-```bash
-$ sbt new typelevel/sbt-catalysts.g8
-```
-
-This will generate a project with a suite
-of library dependencies and compiler plugins,
-together with templates for unit tests
-and documentation.
-See the project pages for [catalysts][link-catalysts]
-and [sbt-catalysts][link-sbt-catalysts]
-for more information.

--- a/src/pages/preface/versions.md
+++ b/src/pages/preface/versions.md
@@ -11,7 +11,8 @@ libraryDependencies +=
   "org.typelevel" %% "cats-core" % "@CATS_VERSION@"
 
 scalacOptions ++= Seq(
-  "-Xfatal-warnings"
+  "-explain",
+  "-Werror"
 )
 ```
 

--- a/src/pages/type-classes/anatomy.md
+++ b/src/pages/type-classes/anatomy.md
@@ -141,26 +141,25 @@ for the using clauses and fills them in for us:
 Person("Dave", "dave@example.com").toJson(using personWriter)
 ```
 
-**The *implicitly* Method**
+**The *summon* Method**
 
 The Scala standard library provides
-a generic type class interface called `implicitly`.
+a generic type class interface called `summon`.
 Its definition is very simple:
 
 ```scala
-def implicitly[A](using value: A): A =
-  value
+def summon[A](using value: A): A = value
 ```
 
-We can use `implicitly` to summon any value from implicit scope.
-We provide the type we want and `implicitly` does the rest:
+We can use `summon` to summon any value from the contextual abstractions scope.
+We provide the type we want and `summon` does the rest:
 
 ```scala mdoc
-implicitly[JsonWriter[String]]
+summon[JsonWriter[String]]
 ```
 
 Most type classes in Cats provide other means to summon instances.
-However, `implicitly` is a good fallback for debugging purposes.
-We can insert a call to `implicitly` within the general flow of our code
+However, `summon` is a good fallback for debugging purposes.
+We can insert a call to `summon` within the general flow of our code
 to ensure the compiler can find an instance of a type class
 and ensure that there are no ambiguous given instances errors.

--- a/src/pages/type-classes/anatomy.md
+++ b/src/pages/type-classes/anatomy.md
@@ -131,11 +131,9 @@ referred to as "type enrichment" or "pimping".
 These are older terms that we don't use anymore.
 
 ```scala mdoc:silent
-object JsonSyntax {
-  implicit class JsonWriterOps[A](value: A) {
-    def toJson(using w: JsonWriter[A]): Json =
-      w.write(value)
-  }
+extension [A](value: A) {
+  def toJson(using w: JsonWriter[A]): Json =
+    w.write(value)
 }
 ```
 
@@ -144,7 +142,6 @@ alongside the instances for the types we need:
 
 ```scala mdoc:silent
 import JsonWriterInstances.personWriter
-import JsonSyntax._
 ```
 
 ```scala mdoc

--- a/src/pages/type-classes/anatomy.md
+++ b/src/pages/type-classes/anatomy.md
@@ -27,11 +27,14 @@ as follows:
 
 ```scala mdoc:silent:reset-object
 // Define a very simple JSON AST
-sealed trait Json
-final case class JsObject(get: Map[String, Json]) extends Json
-final case class JsString(get: String) extends Json
-final case class JsNumber(get: Double) extends Json
-final case object JsNull extends Json
+enum Json {
+  case JsObject(get: Map[String, Json])
+  case JsString(get: String)
+  case JsNumber(get: Double)
+  case JsNull
+}
+
+import Json.*
 
 // The "serialize to JSON" behaviour is encoded in this trait
 trait JsonWriter[A] {

--- a/src/pages/type-classes/anatomy.md
+++ b/src/pages/type-classes/anatomy.md
@@ -5,14 +5,14 @@ the *type class* itself,
 *instances* for particular types,
 and the methods that *use* type classes.
 
-Type classes in Scala are implemented using *implicit values* and *parameters*,
-and optionally using *implicit classes*.
+Type classes in Scala are implemented using *traits*, *given instances* and *using clauses*,
+and optionally using *extension methods*.
 Scala language constructs correspond to the components of type classes as follows:
 
 - traits: type classes;
-- implicit values: type class instances;
-- implicit parameters: type class use; and
-- implicit classes: optional utilities that make type classes easier to use.
+- given instances: type class instances;
+- using clauses: type class use; and
+- extension methods: optional utilities that make type classes easier to use.
 
 Let's see how this works in detail.
 

--- a/src/pages/type-classes/cats.md
+++ b/src/pages/type-classes/cats.md
@@ -34,12 +34,8 @@ The companion object of every Cats type class has an `apply` method
 that locates an instance for any type we specify:
 
 ```scala mdoc
-val showInt = Show.apply[Int]
+given showInt: Show[Int] = Show.apply[Int]
 ```
-
-Oops---that didn't work!
-The `apply` method uses *implicits* to look up individual instances,
-so we'll have to bring some instances into scope.
 
 ### Importing Default Instances {#sec:importing-default-instances}
 

--- a/src/pages/type-classes/cats.md
+++ b/src/pages/type-classes/cats.md
@@ -123,11 +123,9 @@ simply by implementing the trait for a given type:
 ```scala mdoc:silent
 import java.util.Date
 
-implicit val dateShow: Show[Date] =
-  new Show[Date] {
-    def show(date: Date): String =
-      s"${date.getTime}ms since the epoch."
-  }
+given dateShow: Show[Date] with
+  def show(date: Date): String =
+    s"${date.getTime}ms since the epoch."
 ```
 ```scala mdoc
 new Date().show
@@ -158,7 +156,7 @@ import cats.Show
 import java.util.Date
 ```
 ```scala mdoc:silent
-implicit val dateShow: Show[Date] =
+given dateShow: Show[Date] =
   Show.show(date => s"${date.getTime}ms since the epoch.")
 ```
 
@@ -196,7 +194,7 @@ In the companion object we replace our `Printable` with an instance of `Show`
 using one of the definition helpers discussed above:
 
 ```scala mdoc:silent
-implicit val catShow: Show[Cat] = Show.show[Cat] { cat =>
+given catShow: Show[Cat] = Show.show[Cat] { cat =>
   val name  = cat.name.show
   val age   = cat.age.show
   val color = cat.color.show

--- a/src/pages/type-classes/cats.md
+++ b/src/pages/type-classes/cats.md
@@ -62,8 +62,8 @@ Let's import the instances of `Show` for `Int` and `String`:
 
 ```scala mdoc:reset:silent
 import cats.Show
-import cats.instances.int._    // for Show
-import cats.instances.string._ // for Show
+import cats.instances.int.*    // for Show
+import cats.instances.string.* // for Show
 
 val showInt:    Show[Int]    = Show.apply[Int]
 val showString: Show[String] = Show.apply[String]
@@ -88,7 +88,7 @@ This adds an extension method called `show`
 to any type for which we have an instance of `Show` in scope:
 
 ```scala mdoc:silent
-import cats.syntax.show._ // for show
+import cats.syntax.show.* // for show
 ```
 
 ```scala mdoc
@@ -107,9 +107,9 @@ exactly which instances and syntax you need in each example.
 However, this doesn't add value in production code.
 It is simpler and faster to use the following imports:
 
-- `import cats._` imports all of Cats' type classes in one go;
+- `import cats.*` imports all of Cats' type classes in one go;
 
-- `import cats.implicits._` imports
+- `import cats.implicits.*` imports
   all of the standard type class instances
   *and* all of the syntax in one go.
 
@@ -177,9 +177,9 @@ and the interface syntax:
 
 ```scala mdoc:reset-object:silent
 import cats.Show
-import cats.instances.int._    // for Show
-import cats.instances.string._ // for Show
-import cats.syntax.show._      // for show
+import cats.instances.int.*    // for Show
+import cats.instances.string.* // for Show
+import cats.syntax.show.*      // for show
 ```
 
 Our definition of `Cat` remains the same:

--- a/src/pages/type-classes/cats.md
+++ b/src/pages/type-classes/cats.md
@@ -17,9 +17,8 @@ Here's an abbreviated definition:
 ```scala
 package cats
 
-trait Show[A] {
+trait Show[A]:
   def show(value: A): String
-}
 ```
 
 ### Importing Type Classes
@@ -137,7 +136,7 @@ There are two construction methods on the companion object of `Show`
 that we can use to define instances for our own types:
 
 ```scala
-object Show {
+object Show:
   // Convert a function to a `Show` instance:
   def show[A](f: A => String): Show[A] =
     ???
@@ -145,7 +144,6 @@ object Show {
   // Create a `Show` instance from a `toString` method:
   def fromToString[A]: Show[A] =
     ???
-}
 ```
 
 These allow us to quickly construct instances

--- a/src/pages/type-classes/equal.md
+++ b/src/pages/type-classes/equal.md
@@ -57,7 +57,7 @@ import cats.Eq
 Now let's grab an instance for `Int`:
 
 ```scala mdoc:silent
-import cats.instances.int._ // for Eq
+import cats.instances.int.* // for Eq
 
 val eqInt = Eq[Int]
 ```
@@ -81,7 +81,7 @@ We can also import the interface syntax in [`cats.syntax.eq`][cats.syntax.eq]
 to use the `===` and `=!=` methods:
 
 ```scala mdoc:silent
-import cats.syntax.eq._ // for === and =!=
+import cats.syntax.eq.* // for === and =!=
 ```
 
 ```scala mdoc
@@ -102,8 +102,8 @@ To compare values of type `Option[Int]`
 we need to import instances of `Eq` for `Option` as well as `Int`:
 
 ```scala mdoc:silent
-import cats.instances.int._    // for Eq
-import cats.instances.option._ // for Eq
+import cats.instances.int.*    // for Eq
+import cats.instances.option.* // for Eq
 ```
 
 Now we can try some comparisons:
@@ -131,7 +131,7 @@ Option(1) === Option.empty[Int]
 or using special syntax from [`cats.syntax.option`][cats.syntax.option]:
 
 ```scala mdoc:silent
-import cats.syntax.option._ // for some and none
+import cats.syntax.option.* // for some and none
 ```
 
 ```scala mdoc
@@ -146,7 +146,7 @@ which accepts a function of type `(A, A) => Boolean` and returns an `Eq[A]`:
 
 ```scala mdoc:silent
 import java.util.Date
-import cats.instances.long._ // for Eq
+import cats.instances.long.* // for Eq
 ```
 
 ```scala mdoc:silent
@@ -192,7 +192,7 @@ We'll bring instances of `Eq` into scope as we need them below:
 
 ```scala mdoc:silent:reset-object
 import cats.Eq
-import cats.syntax.eq._ // for ===
+import cats.syntax.eq.* // for ===
 ```
 
 Our `Cat` class is the same as ever:
@@ -205,8 +205,8 @@ We bring the `Eq` instances for `Int` and `String`
 into scope for the implementation of `Eq[Cat]`:
 
 ```scala mdoc:silent
-import cats.instances.int._    // for Eq
-import cats.instances.string._ // for Eq
+import cats.instances.int.*    // for Eq
+import cats.instances.string.* // for Eq
 
 given catEqual: Eq[Cat] =
   Eq.instance[Cat] { (cat1, cat2) =>
@@ -227,7 +227,7 @@ cat1 =!= cat2
 ```
 
 ```scala mdoc:silent
-import cats.instances.option._ // for Eq
+import cats.instances.option.* // for Eq
 ```
 
 ```scala mdoc

--- a/src/pages/type-classes/equal.md
+++ b/src/pages/type-classes/equal.md
@@ -151,7 +151,7 @@ import cats.instances.long._ // for Eq
 ```
 
 ```scala mdoc:silent
-implicit val dateEq: Eq[Date] =
+given dateEq: Eq[Date] =
   Eq.instance[Date] { (date1, date2) =>
     date1.getTime === date2.getTime
   }
@@ -209,7 +209,7 @@ into scope for the implementation of `Eq[Cat]`:
 import cats.instances.int._    // for Eq
 import cats.instances.string._ // for Eq
 
-implicit val catEqual: Eq[Cat] =
+given catEqual: Eq[Cat] =
   Eq.instance[Cat] { (cat1, cat2) =>
     (cat1.name  === cat2.name ) &&
     (cat1.age   === cat2.age  ) &&

--- a/src/pages/type-classes/equal.md
+++ b/src/pages/type-classes/equal.md
@@ -34,10 +34,9 @@ between instances of any given type:
 ```scala
 package cats
 
-trait Eq[A] {
+trait Eq[A]:
   def eqv(a: A, b: A): Boolean
   // other concrete methods based on eqv...
-}
 ```
 
 The interface syntax, defined in [`cats.syntax.eq`][cats.syntax.eq],

--- a/src/pages/type-classes/implicits.md
+++ b/src/pages/type-classes/implicits.md
@@ -169,10 +169,9 @@ Here is the same code written out as a `given` with a `using` clause:
 ```scala mdoc:silent
 given optionWriter[A](using writer: JsonWriter[A]): JsonWriter[Option[A]] with
   def write(option: Option[A]): Json =
-    option match {
+    option match
       case Some(aValue) => writer.write(aValue)
       case None         => Json.JsNull
-    }
 ```
 
 This method *constructs* a `JsonWriter` for `Option[A]` by

--- a/src/pages/type-classes/implicits.md
+++ b/src/pages/type-classes/implicits.md
@@ -3,11 +3,14 @@
 ```scala mdoc:invisible
 // Forward definitions
 
-sealed trait Json
-case class JsObject(get: Map[String, Json]) extends Json
-case class JsString(get: String) extends Json
-case class JsNumber(get: Double) extends Json
-case object JsNull extends Json
+enum Json {
+  case JsObject(get: Map[String, Json])
+  case JsString(get: String)
+  case JsNumber(get: Double)
+  case JsNull
+}
+
+import Json.*
 
 trait JsonWriter[A] {
   def write(value: A): Json
@@ -89,11 +92,14 @@ Furthermore, if the compiler sees multiple candidate definitions,
 it fails with an *ambiguous implicit values* error:
 
 ```scala mdoc:invisible:reset-object
-sealed trait Json
-case class JsObject(get: Map[String, Json]) extends Json
-case class JsString(get: String) extends Json
-case class JsNumber(get: Double) extends Json
-case object JsNull extends Json
+enum Json {
+  case JsObject(get: Map[String, Json])
+  case JsString(get: String)
+  case JsNumber(get: Double)
+  case JsNull
+}
+
+import Json.*
 
 trait JsonWriter[A] {
   def write(value: A): Json

--- a/src/pages/type-classes/implicits.md
+++ b/src/pages/type-classes/implicits.md
@@ -1,4 +1,4 @@
-## Working with Given Instances and Using Clauses
+## Working with Contextual Abstractions
 
 ```scala mdoc:invisible
 // Forward definitions
@@ -36,7 +36,7 @@ Working with type classes in Scala means
 working with given instances and using clauses.
 There are a few rules we need to know to do this effectively.
 
-### Implicit Scope
+### Contextual Abstractions Scope
 
 As we saw above, the compiler searches
 for candidate type class instances by type.
@@ -49,10 +49,10 @@ Json.toJson("A string!")
 ```
 
 The places where the compiler searches for candidate instances
-is known as the *implicit scope*.
-The implicit scope applies at the call site;
+is known as the *contextual abstractions scope*.
+The contextual abstractions scope applies at the call site;
 that is the point where we call a method with a using clause.
-The implicit scope which roughly consists of:
+The contextual abstractions scope which roughly consists of:
 
 - local or inherited definitions;
 
@@ -101,14 +101,14 @@ For our purposes, we can package type class instances in roughly five ways:
 
 With option 1 and 2 we bring given instances into scope by `importing` them explicitly.
 With option 3 we bring them into scope with inheritance.
-With options 4 and 5 instances are *always* in implicit scope,
+With options 4 and 5 instances are *always* in the contextual abstractions scope,
 regardless of where we try to use them.
 
 It is conventional to put type class instances in a companion object (option 4 and 5 above)
 if there is only one sensible implementation,
 or at least one implementation that is widely accepted as the default.
 This makes type class instances easier to use
-as no import is required to bring them into the implicit scope.
+as no import is required to bring them into the contextual abstractions scope.
 
 [^implicit-search]: If you're interested in the finer rules of implicit resolution in Scala,
 start by taking a look at [this Stack Overflow post on implicit scope][link-so-implicit-scope]
@@ -203,7 +203,9 @@ a combination that creates a type class instance
 of the correct overall type.
 
 <div class="callout callout-warning">
-*Implicit Conversions*
+*Contextual Implicit Conversions*
+
+// TODO: https://docs.scala-lang.org/scala3/reference/contextual/conversions.html
 
 When you create a type class instance constructor
 using an `given`,
@@ -230,11 +232,6 @@ trait JsonWriter[A]:
 ```scala modc:warn
 given optionWriter[A](writer: JsonWriter[A]): JsonWriter[Option[A]] =
   ???
-// warning: implicit conversion method foo should be enabled
-// by making the implicit value scala.language.implicitConversions visible.
-// This can be achieved by adding the import clause 'import scala.language.implicitConversions'
-// or by setting the compiler option -language:implicitConversions.
-// See the Scaladoc for value scala.language.implicitConversions for a discussion
-// why the feature should be explicitly enabled.
+// TODO: Fix formatting
 ```
 </div>

--- a/src/pages/type-classes/implicits.md
+++ b/src/pages/type-classes/implicits.md
@@ -84,8 +84,7 @@ object Json:
     w.write(value)
 ```
 ```scala mdoc:fail
-given secondStringWriter: JsonWriter[String] =
-  JsonWriterInstances.stringWriter
+given secondStringWriter: JsonWriter[String] = stringWriter
 
 Json.toJson("A string")
 ```
@@ -183,15 +182,15 @@ When the compiler sees an expression like this:
 Json.toJson(Option("A string"))
 ```
 
-it searches for an implicit `JsonWriter[Option[String]]`.
-It finds the implicit method for `JsonWriter[Option[A]]`:
+it searches for a given instance `JsonWriter[Option[String]]`.
+It finds the given instance for `JsonWriter[Option[A]]`:
 
 ```scala mdoc:silent
 Json.toJson(Option("A string"))(using optionWriter[String])
 ```
 
 and recursively searches for a `JsonWriter[String]`
-to use as the parameter to `optionWriter`:
+for the using clause to `optionWriter`:
 
 ```scala mdoc:silent
 Json.toJson(Option("A string"))(using optionWriter(using stringWriter))
@@ -216,7 +215,7 @@ fill in the parameters during given instance resolution.
 `given` methods with non-`using` parameters
 form a different Scala pattern called an *implicit conversion*. 
 This is also different from the previous section on `Interface Syntax`, 
-because in that case the `JsonWriter` is an implicit class with extension methods. 
+because in that case the `JsonWriter` has extension methods. 
 Implicit conversion is an older programming pattern
 that is frowned upon in modern Scala code.
 Fortunately, the compiler will warn you when you do this.

--- a/src/pages/type-classes/instance-selection.md
+++ b/src/pages/type-classes/instance-selection.md
@@ -59,8 +59,11 @@ anywhere we expect a `List[Shape]` because
 `Circle` is a subtype of `Shape`:
 
 ```scala mdoc:silent
-sealed trait Shape
-case class Circle(radius: Double) extends Shape
+enum Shape {
+  case Circle(radius: Double)
+}
+
+import Shape.Circle
 ```
 
 ```scala

--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -152,24 +152,18 @@ by defining some extension methods to provide better syntax:
 First we define an `implicit class` containing our extension methods:
 
 ```scala mdoc:silent
-object PrintableSyntax {
-  implicit class PrintableOps[A](value: A) {
-    def format(using p: Printable[A]): String =
-      p.format(value)
+extension [A](value: A) {
+  def format(using p: Printable[A]): String =
+    p.format(value)
 
-    def print(using p: Printable[A]): Unit =
-      println(format(using p))
-  }
+  def print(using p: Printable[A]): Unit =
+    println(format(using p))
 }
 ```
 
 With `PrintableOps` in scope,
 we can call the imaginary `print` and `format` methods
 on any value for which Scala can locate an implicit instance of `Printable`:
-
-```scala mdoc:silent
-import PrintableSyntax._
-```
 
 ```scala mdoc
 Cat("Garfield", 41, "ginger and black").print

--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -132,24 +132,21 @@ Printable.print(cat)
 Let's make our printing library easier to use
 by defining some extension methods to provide better syntax:
 
- 1. Create an object called `PrintableSyntax`.
+ 1. Define an `extension [A](value: A)` to wrap up a value of type `A`.
 
- 2. Inside `PrintableSyntax` define an `implicit class PrintableOps[A]`
-    to wrap up a value of type `A`.
+ 2. Define the following extension methods:
 
- 3. In `PrintableOps` define the following methods:
-
-     - `format` accepts an implicit `Printable[A]`
+     - `format` using an implicit `Printable[A]`
        and returns a `String` representation of the wrapped `A`;
 
-     - `print` accepts an implicit `Printable[A]` and returns `Unit`.
+     - `print` using an implicit `Printable[A]` and returns `Unit`.
        It prints the wrapped `A` to the console.
 
- 4. Use the extension methods to print the example `Cat`
+  3. Use the extension methods to print the example `Cat`
     you created in the previous exercise.
 
 <div class="solution">
-First we define an `implicit class` containing our extension methods:
+First we define our extension methods:
 
 ```scala mdoc:silent
 extension [A](value: A) {
@@ -161,7 +158,7 @@ extension [A](value: A) {
 }
 ```
 
-With `PrintableOps` in scope,
+With the extensions in scope,
 we can call the imaginary `print` and `format` methods
 on any value for which Scala can locate an implicit instance of `Printable`:
 

--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -12,8 +12,7 @@ Let's define a `Printable` type class to work around these problems:
  1. Define a type class `Printable[A]` containing a single method `format`.
     `format` should accept a value of type `A` and return a `String`.
 
- 2. Create an object `PrintableInstances`
-    containing instances of `Printable` for `String` and `Int`.
+ 2. Create instances of `Printable` for `String` and `Int`.
 
  3. Define an object `Printable` with two generic interface methods:
 
@@ -29,34 +28,30 @@ These steps define the three main components of our type class.
 First we define `Printable`---the *type class* itself:
 
 ```scala mdoc:silent:reset-object
-trait Printable[A] {
+trait Printable[A]:
   def format(value: A): String
-}
 ```
 
 Then we define some default *instances* of `Printable`
 and package them in `PrintableInstances`:
 
 ```scala mdoc:silent
-object PrintableInstances {
-  given stringPrintable: Printable[String] with
-    def format(input: String) = input
+given stringPrintable: Printable[String] with
+  def format(input: String) = input
 
-  given intPrintable: Printable[Int] with
-    def format(input: Int) = input.toString
-}
+given intPrintable: Printable[Int] with
+  def format(input: Int) = input.toString
 ```
 
 Finally we define an *interface* object, `Printable`:
 
 ```scala mdoc:silent
-object Printable {
+object Printable:
   def format[A](input: A)(using p: Printable[A]): String =
     p.format(input)
 
   def print[A](input: A)(using p: Printable[A]): Unit =
     println(p.format(input))
-}
 ```
 </div>
 
@@ -102,8 +97,6 @@ These either go into the companion object of `Cat`
 or a separate object to act as a namespace:
 
 ```scala mdoc:silent
-import PrintableInstances.{intPrintable, stringPrintable}
-
 given catPrintable: Printable[Cat] with
   def format(cat: Cat) = {
     val name  = Printable.format(cat.name)
@@ -149,13 +142,12 @@ by defining some extension methods to provide better syntax:
 First we define our extension methods:
 
 ```scala mdoc:silent
-extension [A](value: A) {
+extension [A](value: A)
   def format(using p: Printable[A]): String =
     p.format(value)
 
   def print(using p: Printable[A]): Unit =
     println(format(using p))
-}
 ```
 
 With the extensions in scope,

--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -32,8 +32,7 @@ trait Printable[A]:
   def format(value: A): String
 ```
 
-Then we define some default *instances* of `Printable`
-and package them in `PrintableInstances`:
+Then we define some default *instances* of `Printable`:
 
 ```scala mdoc:silent
 given stringPrintable: Printable[String] with
@@ -129,10 +128,10 @@ by defining some extension methods to provide better syntax:
 
  2. Define the following extension methods:
 
-     - `format` using an implicit `Printable[A]`
+     - `format` using a `Printable[A]`
        and returns a `String` representation of the wrapped `A`;
 
-     - `print` using an implicit `Printable[A]` and returns `Unit`.
+     - `print` using a `Printable[A]` and returns `Unit`.
        It prints the wrapped `A` to the console.
 
   3. Use the extension methods to print the example `Cat`

--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -39,13 +39,11 @@ and package them in `PrintableInstances`:
 
 ```scala mdoc:silent
 object PrintableInstances {
-  implicit val stringPrintable: Printable[String] = new Printable[String] {
+  given stringPrintable: Printable[String] with
     def format(input: String) = input
-  }
 
-  implicit val intPrintable: Printable[Int] = new Printable[Int] {
+  given intPrintable: Printable[Int] with
     def format(input: Int) = input.toString
-  }
 }
 ```
 
@@ -53,10 +51,10 @@ Finally we define an *interface* object, `Printable`:
 
 ```scala mdoc:silent
 object Printable {
-  def format[A](input: A)(implicit p: Printable[A]): String =
+  def format[A](input: A)(using p: Printable[A]): String =
     p.format(input)
 
-  def print[A](input: A)(implicit p: Printable[A]): Unit =
+  def print[A](input: A)(using p: Printable[A]): Unit =
     println(p.format(input))
 }
 ```
@@ -104,16 +102,15 @@ These either go into the companion object of `Cat`
 or a separate object to act as a namespace:
 
 ```scala mdoc:silent
-import PrintableInstances._
+import PrintableInstances.{intPrintable, stringPrintable}
 
-implicit val catPrintable: Printable[Cat] = new Printable[Cat] {
+given catPrintable: Printable[Cat] with
   def format(cat: Cat) = {
     val name  = Printable.format(cat.name)
     val age   = Printable.format(cat.age)
     val color = Printable.format(cat.color)
     s"$name is a $age year-old $color cat."
   }
-}
 ```
 
 Finally, we use the type class by
@@ -157,11 +154,11 @@ First we define an `implicit class` containing our extension methods:
 ```scala mdoc:silent
 object PrintableSyntax {
   implicit class PrintableOps[A](value: A) {
-    def format(implicit p: Printable[A]): String =
+    def format(using p: Printable[A]): String =
       p.format(value)
 
-    def print(implicit p: Printable[A]): Unit =
-      println(format(p))
+    def print(using p: Printable[A]): Unit =
+      println(format(using p))
   }
 }
 ```

--- a/src/pages/type-classes/printable.md
+++ b/src/pages/type-classes/printable.md
@@ -39,11 +39,11 @@ and package them in `PrintableInstances`:
 
 ```scala mdoc:silent
 object PrintableInstances {
-  implicit val stringPrintable = new Printable[String] {
+  implicit val stringPrintable: Printable[String] = new Printable[String] {
     def format(input: String) = input
   }
 
-  implicit val intPrintable = new Printable[Int] {
+  implicit val intPrintable: Printable[Int] = new Printable[Int] {
     def format(input: Int) = input.toString
   }
 }
@@ -106,7 +106,7 @@ or a separate object to act as a namespace:
 ```scala mdoc:silent
 import PrintableInstances._
 
-implicit val catPrintable = new Printable[Cat] {
+implicit val catPrintable: Printable[Cat] = new Printable[Cat] {
   def format(cat: Cat) = {
     val name  = Printable.format(cat.name)
     val age   = Printable.format(cat.age)

--- a/src/pages/type-classes/summary.md
+++ b/src/pages/type-classes/summary.md
@@ -8,9 +8,9 @@ We saw the components that make up a type class:
 
 - A `trait`, which is the type class
 
-- Type class instances, which are implicit values.
+- Type class instances, which are given instances.
 
-- Type class usage, which uses implicit parameters.
+- Type class usage, which utilizes using clauses.
 
 
 We have also seen the general patterns in Cats type classes:

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,8 +96,8 @@ coffeeify@1.0.0:
     through "^2.3.6"
 
 coffeescript@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-2.7.0.tgz"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"


### PR DESCRIPTION
As an excuse to better learn cats and scala 3 I started with an overhaul.

This is still a work in progress. (Checking by building `sbt pdf`)

TODOS:

- [x] Upgrade deps and address deprecations/warnings (*)
- [x] Use `given`/`using` in lieu of `implicit val`
- [x] Use `given` in lieu of `implicit def`
- [x] Use `extension` in lieu of `implicit class`
- [x] Use `enum` in lieu of `sealed trait/case [class|object]`
- [x] Braceless Syntax / Significant Indent
- [ ] Implement other suggestions from:
  - [ ] https://docs.scala-lang.org/scala3/reference/contextual/type-classes.html
  - [ ] https://docs.scala-lang.org/scala3/reference/contextual/derivation.html
- [ ] More changes?
- [ ] Edit text and get a friend/colleague/someone else to proof-read 

(*) Unaddressed:

```
warning: custom-instances.md:254:43: 
pattern's type ::[repl.MdocSession.MdocApp4.Tree[B]] is more specialized than the right hand side expression's type List[repl.MdocSession.MdocApp4.Tree[B]]

If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
which may result in a MatchError at runtime.
              val left :: right :: tail = acc
                                          ^^^
```