### PR TITLE
Fix footnote in Semigroupal description

### DIFF
--- a/src/pages/applicatives/semigroupal.md
+++ b/src/pages/applicatives/semigroupal.md
@@ -21,7 +21,6 @@ This gives us more freedom when defining
 instances of `Semigroupal` than we get when defining `Monads`.
 
 [^semigroupal-name]: It
-
 is also the winner of Underscore's 2017 award for
 the most difficult functional programming term
 to work into a coherent English sentence.


### PR DESCRIPTION
The empty line is causing the rest of the paragraph to not be included in the footnote.