### PR TITLE
Bump mdoc to fix confusing source position

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.3" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.4" )
 // addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.2")


### PR DESCRIPTION
Fix #250 with `v2.5.4` [^1].

[^1]: https://github.com/scalameta/mdoc/releases/tag/v2.5.4