### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ These are useful for debugging the build.
 
 If you spot a typo or mistake,
 please feel free to fork the repo and submit a Pull Request.
-Add yourself to [contributors.md](src/pages/preface/contributors.md)
+Add yourself to [acknowledgements.md](src/pages/appendices/acknowledgements.md)
 to ensure we credit you for your contribution.
 
 If you don't have time to submit a PR


### PR DESCRIPTION
- Link to 'contributors.md' file is broken on README
- The page 'contributors.md' doesn't seem to exist anymore
- Update credits for contributions from 'contributors.md' to the 'acknowledgements.md' page.

Thanks for submitting a PR to the book!

If you'd like your contribution to be acknowledged in the book, please include in your PR the addition of your name to `src/pages/appendices/acknowledgements.md`. Names are given in alphabetic order.

