### PR TITLE
Use `given` ... `with` syntax

### DIFF
--- a/src/pages/functors/cats.typ
+++ b/src/pages/functors/cats.typ
@@ -171,11 +171,10 @@ even though such a thing already exists in #href("http://typelevel.org/cats/api/
 The implementation is trivial---we simply call `Option's` `map` method:
 
 ```scala
-given optionFunctor: Functor[Option] =
-  new Functor[Option] {
-    def map[A, B](value: Option[A])(func: A => B): Option[B] =
-      value.map(func)
-  }
+given optionFunctor: Functor[Option] with {
+  def map[A, B](value: Option[A])(func: A => B): Option[B] =
+    value.map(func)
+}
 ```
 
 Sometimes we need to inject dependencies into our instances.
@@ -188,11 +187,10 @@ so we have to account for the dependency when we create the instance:
 ```scala mdoc:silent
 import scala.concurrent.{Future, ExecutionContext}
 
-given futureFunctor(using ec: ExecutionContext): Functor[Future] =
-  new Functor[Future] {
-    def map[A, B](value: Future[A])(func: A => B): Future[B] =
-      value.map(func)
-  }
+given futureFunctor(using ec: ExecutionContext): Functor[Future] with {
+  def map[A, B](value: Future[A])(func: A => B): Future[B] =
+    value.map(func)
+}
 ```
 
 Whenever we summon a `Functor` for `Future`,
@@ -237,16 +235,15 @@ with the same pattern of `Branch` and `Leaf` nodes:
 ```scala mdoc:silent
 import Tree.{Branch, Leaf}
 
-given treeFunctor: Functor[Tree] =
-  new Functor[Tree] {
-    def map[A, B](tree: Tree[A])(func: A => B): Tree[B] =
-      tree match {
-        case Branch(left, right) =>
-          Branch(map(left)(func), map(right)(func))
-        case Leaf(value) =>
-          Leaf(func(value))
-      }
-  }
+given treeFunctor: Functor[Tree] with {
+  def map[A, B](tree: Tree[A])(func: A => B): Tree[B] =
+    tree match {
+      case Branch(left, right) =>
+        Branch(map(left)(func), map(right)(func))
+      case Leaf(value) =>
+        Leaf(func(value))
+    }
+}
 ```
 
 Let's use our `Functor` to transform some `Trees`:

--- a/src/pages/functors/contravariant-invariant.typ
+++ b/src/pages/functors/contravariant-invariant.typ
@@ -215,17 +215,15 @@ trait Display[A] {
 def display[A](value: A)(implicit p: Display[A]): String =
   p.display(value)
 
-given stringDisplay: Display[String] =
-  new Display[String] {
-    def display(value: String): String =
-      s"'${value}'"
-  }
+given stringDisplay: Display[String] with {
+  def display(value: String): String =
+    s"'${value}'"
+}
 
-given booleanDisplay: Display[Boolean] =
-  new Display[Boolean] {
-    def display(value: Boolean): String =
-      if(value) "yes" else "no"
-  }
+given booleanDisplay: Display[Boolean] with {
+  def display(value: Boolean): String =
+    if(value) "yes" else "no"
+}
 final case class Box[A](value: A)
 ```
 ```scala mdoc:silent
@@ -365,11 +363,10 @@ trait Codec[A] { self =>
 ```
 
 ```scala mdoc:invisible
-given stringCodec: Codec[String] =
-  new Codec[String] {
-    def encode(value: String): String = value
-    def decode(value: String): String = value
-  }
+given stringCodec: Codec[String] with {
+  def encode(value: String): String = value
+  def decode(value: String): String = value
+}
 
 given intCodec: Codec[Int] =
   stringCodec.imap[Int](_.toInt, _.toString)

--- a/src/pages/indexed-types/codata.typ
+++ b/src/pages/indexed-types/codata.typ
@@ -422,8 +422,8 @@ trait PoundsFeet
 // An instance exists if A * B = C
 trait Multiply[A, B, C]
 object Multiply {
-  given Multiply[Metres, Newtons, NewtonMetres] = new Multiply {}
-  given Multiply[Feet, Pounds, PoundsFeet] = new Multiply {}
+  given Multiply[Metres, Newtons, NewtonMetres] with {}
+  given Multiply[Feet, Pounds, PoundsFeet] with {}
 }
 ```
 
@@ -482,7 +482,7 @@ To solve this I defined a given instance called `commutative`, as shown below.
 // An instance exists if A * B = C
 trait Multiply[A, B, C]
 object Multiply {
-  given Multiply[Metres, Newtons, NewtonMetres] = new Multiply {}
+  given Multiply[Metres, Newtons, NewtonMetres] with {}
   
   // A * B == B * A
   given commutative[A, B, C](using Multiply[A, B, C]): Multiply[B, A, C] =

--- a/src/pages/indexed-types/codata.typ
+++ b/src/pages/indexed-types/codata.typ
@@ -485,8 +485,7 @@ object Multiply {
   given Multiply[Metres, Newtons, NewtonMetres] with {}
   
   // A * B == B * A
-  given commutative[A, B, C](using Multiply[A, B, C]): Multiply[B, A, C] =
-    new Multiply {}
+  given commutative[A, B, C](using Multiply[A, B, C]): Multiply[B, A, C] with {}
 }
 ```
 ```scala mdoc:invisible

--- a/src/pages/monads/custom-instances.typ
+++ b/src/pages/monads/custom-instances.typ
@@ -165,7 +165,7 @@ the non-tail-recursive solution falls out:
 ```scala mdoc:silent
 import cats.Monad
 
-given treeMonad: Monad[Tree] = new Monad[Tree] {
+given treeMonad: Monad[Tree] with {
   def pure[A](value: A): Tree[A] =
     Tree.Leaf(value)
 
@@ -216,7 +216,7 @@ object Tree {
 import cats.Monad
 import scala.annotation.tailrec
 
-given treeMonad: Monad[Tree] = new Monad[Tree] {
+given treeMonad: Monad[Tree] with {
   def pure[A](value: A): Tree[A] =
     Tree.Leaf(value)
 

--- a/src/pages/type-classes/anatomy.typ
+++ b/src/pages/type-classes/anatomy.typ
@@ -64,11 +64,10 @@ given instances implementing the type class.
 
 ```scala mdoc:silent
 object JsonWriterInstances {
-  given stringWriter: JsonWriter[String] =
-    new JsonWriter[String] {
-      def write(value: String): Json =
-        Json.JsString(value)
-    }
+  given stringWriter: JsonWriter[String] with {
+    def write(value: String): Json =
+      Json.JsString(value)
+  }
   
   final case class Person(name: String, email: String)
   
@@ -192,11 +191,10 @@ trait JsonWriter[A] {
 }
 
 object JsonWriter {
-  given stringWriter: JsonWriter[String] =
-    new JsonWriter[String] {
-      extension (value: String) 
-        def toJson: Json = Json.JsString(value)
-    }
+  given stringWriter: JsonWriter[String] with {
+    extension (value: String) 
+      def toJson: Json = Json.JsString(value)
+  }
   
   // etc...
 }

--- a/src/pages/type-classes/composition.typ
+++ b/src/pages/type-classes/composition.typ
@@ -41,11 +41,13 @@ We could try to brute force the problem by creating
 a library of given instances:
 
 ```scala
-given optionIntWriter: JsonWriter[Option[Int]] =
+given optionIntWriter: JsonWriter[Option[Int]] with {
   ???
+}
 
-given optionPersonWriter: JsonWriter[Option[Person]] =
+given optionPersonWriter: JsonWriter[Option[Person]] with {
   ???
+}
 
 // and so on...
 ```
@@ -66,14 +68,13 @@ into a common constructor based on the instance for `A`:
 Here is the same code written out using a parameterized given instance:
 
 ```scala mdoc:silent
-given optionWriter[A](using writer: JsonWriter[A]): JsonWriter[Option[A]] =
-  new JsonWriter[Option[A]] {
-    def write(option: Option[A]): Json =
-      option match {
-        case Some(aValue) => writer.write(aValue)
-        case None         => Json.JsNull
-      }
-  }
+given optionWriter[A](using writer: JsonWriter[A]): JsonWriter[Option[A]] with {
+  def write(option: Option[A]): Json =
+    option match {
+      case Some(aValue) => writer.write(aValue)
+      case None         => Json.JsNull
+    }
+}
 ```
 
 This method constructs a `JsonWriter` for `Option[A]` by
@@ -82,10 +83,9 @@ fill in the `A`-specific functionality.
 When the compiler sees an expression like this:
 
 ```scala mdoc:invisible
-given stringWriter: JsonWriter[String] =
-  new JsonWriter[String] {
-    def write(value: String): Json = Json.JsString(value)
-  }
+given stringWriter: JsonWriter[String] with {
+  def write(value: String): Json = Json.JsString(value)
+}
 ```
 ```scala mdoc:silent
 Json.toJson(Option("A string"))

--- a/src/pages/type-classes/display.typ
+++ b/src/pages/type-classes/display.typ
@@ -130,7 +130,7 @@ These either go into the companion object of `Cat`
 or a separate object to act as a namespace:
 
 ```scala mdoc:silent
-given catDisplay: Display[Cat] = new Display[Cat] {
+given catDisplay: Display[Cat] with {
   def display(cat: Cat) = {
     val name  = Display.display(cat.name)
     val age   = Display.display(cat.age)

--- a/src/pages/type-classes/given.typ
+++ b/src/pages/type-classes/given.typ
@@ -186,18 +186,16 @@ Now we'll define some given instances. Notice that they are defined on the relev
 ```scala mdoc:silent
 trait Cat
 object Cat {
-  given catSound: Sound[Cat] =
-    new Sound[Cat]{
-      def sound: String = "meow"
-    }
+  given catSound: Sound[Cat] with {
+    def sound: String = "meow"
+  }
 }
 
 trait Dog
 object Dog {
-  given dogSound: Sound[Dog] = 
-    new Sound[Dog]{
-      def sound: String = "woof"
-    }
+  given dogSound: Sound[Dog] with {
+    def sound: String = "woof"
+  }
 }
 ```
 

--- a/src/pages/type-classes/given.typ
+++ b/src/pages/type-classes/given.typ
@@ -235,10 +235,9 @@ trait Sound[A] {
 }
 trait Cat
 object Cat {
-  given catSound: Sound[Cat] =
-    new Sound[Cat]{
-      def sound: String = "meow"
-    }
+  given catSound: Sound[Cat] with {
+    def sound: String = "meow"
+  }
 }
 
 def soundOf[A](using s: Sound[A]): String =
@@ -248,10 +247,9 @@ def soundOf[A](using s: Sound[A]): String =
 Now we define an instance in the lexical scope, and we see it is chosen in preference to the instance on the companion object.
 
 ```scala mdoc
-given purr: Sound[Cat]  =
-  new Sound[Cat]{
-    def sound: String = "purr"
-  }
+given purr: Sound[Cat] with {
+  def sound: String = "purr"
+}
 
 soundOf[Cat]
 ```
@@ -260,16 +258,14 @@ The final rule is that instances in a closer lexical scope take preference over 
 
 ```scala mdoc
 {
-  given growl: Sound[Cat] =
-   new Sound[Cat]{
-     def sound: String = "growl"
-   }
+  given growl: Sound[Cat] with {
+    def sound: String = "growl"
+  }
    
   {
-    given mew: Sound[Cat] =
-     new Sound[Cat]{
-       def sound: String = "mew"
-     }
+    given mew: Sound[Cat] with {
+      def sound: String = "mew"
+    }
      
     soundOf[Cat]
   }


### PR DESCRIPTION
Adopting `given` ... `with` syntax makes type class implementations more succinct and idiomatic.